### PR TITLE
Node Info, Node Tree and Click Functions

### DIFF
--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -21,6 +21,7 @@ CoreInstInfoWin.cpp
 CorePInstInfoWin.cpp
 CoreRegClassInfoWin.cpp
 CoreRegInfoWin.cpp
+CoreISAInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -20,6 +20,7 @@ CoreDrawInstFormat.cpp
 CoreInstInfoWin.cpp
 CorePInstInfoWin.cpp
 CoreRegClassInfoWin.cpp
+CoreRegInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -27,6 +27,7 @@ CoreEncodingInfoWin.cpp
 CoreExtInfoWin.cpp
 CoreCommInfoWin.cpp
 CoreSpadInfoWin.cpp
+CoreMCtrlInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -24,6 +24,7 @@ CoreRegInfoWin.cpp
 CoreISAInfoWin.cpp
 CoreCacheInfoWin.cpp
 CoreEncodingInfoWin.cpp
+CoreExtInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -25,6 +25,7 @@ CoreISAInfoWin.cpp
 CoreCacheInfoWin.cpp
 CoreEncodingInfoWin.cpp
 CoreExtInfoWin.cpp
+CoreCommInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -18,6 +18,7 @@ CoreCoreInfoWin.cpp
 CoreInstFormatInfoWin.cpp
 CoreDrawInstFormat.cpp
 CoreInstInfoWin.cpp
+CorePInstInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -15,6 +15,8 @@ CoreVerifConfig.cpp
 CoreInfoWin.cpp
 CoreSocInfoWin.cpp
 CoreCoreInfoWin.cpp
+CoreInstFormatInfoWin.cpp
+CoreDrawInstFormat.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -12,6 +12,8 @@ CoreStoneCutterEditor.cpp
 CoreErrorDiag.cpp
 CoreUserConfig.cpp
 CoreVerifConfig.cpp
+CoreInfoWin.cpp
+CoreSocInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -19,6 +19,7 @@ CoreInstFormatInfoWin.cpp
 CoreDrawInstFormat.cpp
 CoreInstInfoWin.cpp
 CorePInstInfoWin.cpp
+CoreRegClassInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -29,6 +29,7 @@ CoreCommInfoWin.cpp
 CoreSpadInfoWin.cpp
 CoreMCtrlInfoWin.cpp
 CoreVTPInfoWin.cpp
+CorePluginInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -17,6 +17,7 @@ CoreSocInfoWin.cpp
 CoreCoreInfoWin.cpp
 CoreInstFormatInfoWin.cpp
 CoreDrawInstFormat.cpp
+CoreInstInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -28,6 +28,7 @@ CoreExtInfoWin.cpp
 CoreCommInfoWin.cpp
 CoreSpadInfoWin.cpp
 CoreMCtrlInfoWin.cpp
+CoreVTPInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -14,6 +14,7 @@ CoreUserConfig.cpp
 CoreVerifConfig.cpp
 CoreInfoWin.cpp
 CoreSocInfoWin.cpp
+CoreCoreInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -23,6 +23,7 @@ CoreRegClassInfoWin.cpp
 CoreRegInfoWin.cpp
 CoreISAInfoWin.cpp
 CoreCacheInfoWin.cpp
+CoreEncodingInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -26,6 +26,7 @@ CoreCacheInfoWin.cpp
 CoreEncodingInfoWin.cpp
 CoreExtInfoWin.cpp
 CoreCommInfoWin.cpp
+CoreSpadInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CMakeLists.txt
+++ b/src/CoreGenPortal/PortalCore/CMakeLists.txt
@@ -22,6 +22,7 @@ CorePInstInfoWin.cpp
 CoreRegClassInfoWin.cpp
 CoreRegInfoWin.cpp
 CoreISAInfoWin.cpp
+CoreCacheInfoWin.cpp
 )
 
 #-- target deps

--- a/src/CoreGenPortal/PortalCore/CoreCacheInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreCacheInfoWin.cpp
@@ -1,0 +1,191 @@
+//
+// _CORECACHEINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreCacheInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreCacheInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreCacheInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreCacheInfoWin::CoreCacheInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenCache *Cache)
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Cache == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- cache
+  CacheNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Cache Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  CacheNameText->Wrap(-1);
+  InnerSizer->Add( CacheNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  CacheNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Cache->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("CacheName") );
+  InnerSizer->Add( CacheNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- sets
+  SetsText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Cache Sets"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  SetsText->Wrap(-1);
+  InnerSizer->Add( SetsText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  SetsCtrl = new wxTextCtrl( Wnd,
+                             wxID_ANY,
+                             wxString::Format(wxT("%i"),Cache->GetSets()),
+                             wxDefaultPosition,
+                             wxSize(400,25),
+                             wxTE_READONLY,
+                             wxDefaultValidator,
+                             wxT("Sets") );
+  InnerSizer->Add( SetsCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- ways
+  WaysText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Cache Ways"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  WaysText->Wrap(-1);
+  InnerSizer->Add( WaysText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  WaysCtrl = new wxTextCtrl( Wnd,
+                             wxID_ANY,
+                             wxString::Format(wxT("%i"),Cache->GetWays()),
+                             wxDefaultPosition,
+                             wxSize(400,25),
+                             wxTE_READONLY,
+                             wxDefaultValidator,
+                             wxT("Ways") );
+  InnerSizer->Add( WaysCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- parent cache
+  ParentCacheText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Child Cache Node"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  ParentCacheText->Wrap(-1);
+  InnerSizer->Add( ParentCacheText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  ParentCacheCtrl = new wxTextCtrl( Wnd,
+                             wxID_ANY,
+                             wxEmptyString,
+                             wxDefaultPosition,
+                             wxSize(400,25),
+                             wxTE_READONLY,
+                             wxDefaultValidator,
+                             wxT("ParentCache") );
+  if( Cache->IsParentLevel() ){
+    CoreGenCache *Parent = Cache->GetSubCache();
+    if( Parent != nullptr )
+      ParentCacheCtrl->AppendText(wxString(Parent->GetName()));
+  }
+  InnerSizer->Add( ParentCacheCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- child cache
+  ChildCacheText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Parent Cache Node"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  ChildCacheText->Wrap(-1);
+  InnerSizer->Add( ChildCacheText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  ChildCacheCtrl = new wxTextCtrl( Wnd,
+                             wxID_ANY,
+                             wxEmptyString,
+                             wxDefaultPosition,
+                             wxSize(400,25),
+                             wxTE_READONLY,
+                             wxDefaultValidator,
+                             wxT("ChildCache") );
+  if( Cache->IsSubLevel() ){
+    CoreGenCache *Child = Cache->GetParentCache();
+    if( Child != nullptr )
+      ChildCacheCtrl->AppendText(wxString(Child->GetName()));
+  }
+  InnerSizer->Add( ChildCacheCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreCacheInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreCacheInfoWin::~CoreCacheInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreCacheInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreCacheInfoWin.h
@@ -1,0 +1,89 @@
+//
+// _CORECACHEINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _CORECACHEINFOWIN_H_
+#define _CORECACHEINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreCacheInfoWin : public wxDialog {
+public:
+  CoreCacheInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Inst Node"),
+                 CoreGenCache *Node = nullptr);
+  ~CoreCacheInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *CacheNameText;    ///< static text for cache name
+  wxStaticText *SetsText;         ///< static text for cache sets
+  wxStaticText *WaysText;         ///< static text for cache ways
+  wxStaticText *ParentCacheText;  ///< static text for parent cache
+  wxStaticText *ChildCacheText;   ///< static text for child cache
+
+  wxTextCtrl *CacheNameCtrl;      ///< cache name
+  wxTextCtrl *SetsCtrl;           ///< cache sets
+  wxTextCtrl *WaysCtrl;           ///< cache ways
+  wxTextCtrl *ParentCacheCtrl;    ///< parent cache
+  wxTextCtrl *ChildCacheCtrl;     ///< child cache
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreCommInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreCommInfoWin.cpp
@@ -1,0 +1,180 @@
+//
+// _CORECOMMINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreCommInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreCommInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreCommInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreCommInfoWin::CoreCommInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenComm *Comm )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Comm == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- comm
+  CommNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Communication Node Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  CommNameText->Wrap(-1);
+  InnerSizer->Add( CommNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  CommNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Comm->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("CommName") );
+  InnerSizer->Add( CommNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- comm type
+  CommTypeText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Communication Node Type"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  CommTypeText->Wrap(-1);
+  InnerSizer->Add( CommTypeText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  CommTypeCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxEmptyString,
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("CommType") );
+  switch( Comm->GetCommType() ){
+  case CGCommP2P:
+    CommTypeCtrl->AppendText(wxT("Point-to-Point"));
+    break;
+  case CGCommBus:
+    CommTypeCtrl->AppendText(wxT("Bus"));
+    break;
+  case CGCommNoc:
+    CommTypeCtrl->AppendText(wxT("Network on Chip"));
+    break;
+  case CGCommUnk:
+  default:
+    CommTypeCtrl->AppendText(wxT("Unknown"));
+    break;
+  }
+  InnerSizer->Add( CommTypeCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- width
+  WidthText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Communication Channel Width"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  WidthText->Wrap(-1);
+  InnerSizer->Add( CommNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  WidthCtrl = new wxTextCtrl( Wnd,
+                              wxID_ANY,
+                              wxString::Format(wxT("%i"),Comm->GetWidth()),
+                              wxDefaultPosition,
+                              wxSize(400,25),
+                              wxTE_READONLY,
+                              wxDefaultValidator,
+                              wxT("CommWidth") );
+  InnerSizer->Add( WidthCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- endpoints
+  EndpointText = new wxStaticText( Wnd,
+                              wxID_ANY,
+                              wxT("Endpoints"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              0 );
+  EndpointText->Wrap(-1);
+  InnerSizer->Add( EndpointText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  EndpointCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxEmptyString,
+                            wxDefaultPosition,
+                            wxSize(400,100),
+                            wxTE_READONLY|wxTE_MULTILINE|wxHSCROLL,
+                            wxDefaultValidator,
+                            wxT("endpoints") );
+
+  for( unsigned i=0; i<Comm->GetNumEndpoints(); i++ ){
+    EndpointCtrl->AppendText(wxString(Comm->GetEndpoint(i)->GetName())+wxT("\n") );
+  }
+  InnerSizer->Add( EndpointCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreCommInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreCommInfoWin::~CoreCommInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreCommInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreCommInfoWin.h
@@ -1,5 +1,5 @@
 //
-// _CORECACHEINFOWIN_H_
+// _CORECOMMINFOWIN_H_
 //
 // Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#ifndef _CORECACHEINFOWIN_H_
-#define _CORECACHEINFOWIN_H_
+#ifndef _CORECOMMINFOWIN_H_
+#define _CORECOMMINFOWIN_H_
 
 //-- WX HEADERS
 #include <wx/artprov.h>
@@ -39,13 +39,13 @@
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"
 
-class CoreCacheInfoWin : public wxDialog {
+class CoreCommInfoWin : public wxDialog {
 public:
-  CoreCacheInfoWin( wxWindow* parent,
+  CoreCommInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Cache Node"),
-                 CoreGenCache *Node = nullptr);
-  ~CoreCacheInfoWin();
+                 const wxString& title = wxT("Comm Node"),
+                 CoreGenComm *Node = nullptr);
+  ~CoreCommInfoWin();
 
   // Event handler functions
   /// Declares the event table
@@ -65,17 +65,15 @@ protected:
   // static lines
   wxStaticLine* FinalStaticLine;  ///< final static line
 
-  wxStaticText *CacheNameText;    ///< static text for cache name
-  wxStaticText *SetsText;         ///< static text for cache sets
-  wxStaticText *WaysText;         ///< static text for cache ways
-  wxStaticText *ParentCacheText;  ///< static text for parent cache
-  wxStaticText *ChildCacheText;   ///< static text for child cache
+  wxStaticText *CommNameText;     ///< static text for SoC name
+  wxStaticText *CommTypeText;     ///< static text for inst format
+  wxStaticText *WidthText;        ///< static text for width
+  wxStaticText *EndpointText;     ///< static text for endpoints
 
-  wxTextCtrl *CacheNameCtrl;      ///< cache name
-  wxTextCtrl *SetsCtrl;           ///< cache sets
-  wxTextCtrl *WaysCtrl;           ///< cache ways
-  wxTextCtrl *ParentCacheCtrl;    ///< parent cache
-  wxTextCtrl *ChildCacheCtrl;     ///< child cache
+  wxTextCtrl *CommNameCtrl;       ///< comm name
+  wxTextCtrl *CommTypeCtrl;       ///< comm type
+  wxTextCtrl *WidthCtrl;          ///< width
+  wxTextCtrl *EndpointCtrl;       ///< endpoints
 
   // buttons
   wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer

--- a/src/CoreGenPortal/PortalCore/CoreCoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreCoreInfoWin.cpp
@@ -1,0 +1,207 @@
+//
+// _CORECOREINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreCoreInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreCoreInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreCoreInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreCoreInfoWin::CoreCoreInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenCore *Core )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Core == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the box sizers
+  wxBoxSizer *bSizer2 = new wxBoxSizer( wxVERTICAL );
+
+  m_panel1 = new wxPanel( this,
+                          wxID_ANY,
+                          wxDefaultPosition,
+                          wxDefaultSize,
+                          wxTAB_TRAVERSAL );
+  bSizer2->Add( m_panel1, 1, wxEXPAND|wxALL, 5);
+
+  // init all the options
+  //-- core name
+  CoreNameText = new wxStaticText(this,
+                                 wxID_ANY,
+                                 wxT("Core Name"),
+                                 wxDefaultPosition,
+                                 wxDefaultSize,
+                                 0 );
+  CoreNameText->Wrap(-1);
+  bSizer2->Add( CoreNameText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- core name box
+  CoreNameCtrl = new wxTextCtrl(this,
+                               wxID_ANY,
+                               wxString(Core->GetName()),
+                               wxDefaultPosition,
+                               wxSize(400,25),
+                               wxTE_READONLY,
+                               wxDefaultValidator,
+                               wxT("Core Name") );
+  bSizer2->Add( CoreNameCtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- thread unit name
+  ThreadUnitText = new wxStaticText(this,
+                                 wxID_ANY,
+                                 wxT("Thread Units"),
+                                 wxDefaultPosition,
+                                 wxDefaultSize,
+                                 0 );
+  ThreadUnitText->Wrap(-1);
+  bSizer2->Add( ThreadUnitText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- thread unit number
+  ThreadUnitCtrl = new wxTextCtrl(this,
+                               wxID_ANY,
+                               wxString::Format(wxT("%i"),Core->GetNumThreadUnits()),
+                               wxDefaultPosition,
+                               wxSize(400,25),
+                               wxTE_READONLY,
+                               wxDefaultValidator,
+                               wxT("Thread Units") );
+  bSizer2->Add( ThreadUnitCtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- isa name
+  ISANameText= new wxStaticText(this,
+                                 wxID_ANY,
+                                 wxT("ISA Name"),
+                                 wxDefaultPosition,
+                                 wxDefaultSize,
+                                 0 );
+  ISANameText->Wrap(-1);
+  bSizer2->Add( ISANameText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- isa name ctrl
+  ISACtrl = new wxTextCtrl(this,
+                           wxID_ANY,
+                           wxString(Core->GetISA()->GetName()),
+                           wxDefaultPosition,
+                           wxSize(400,25),
+                           wxTE_READONLY,
+                           wxDefaultValidator,
+                           wxT("ISA") );
+  bSizer2->Add( ISACtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- cache name
+  CacheNameText = new wxStaticText(this,
+                                 wxID_ANY,
+                                 wxT("Cache Name"),
+                                 wxDefaultPosition,
+                                 wxDefaultSize,
+                                 0 );
+  CacheNameText->Wrap(-1);
+  bSizer2->Add( CacheNameText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- cache name ctrl
+  CacheCtrl = new wxTextCtrl(this,
+                           wxID_ANY,
+                           wxString(Core->GetCache()->GetName()),
+                           wxDefaultPosition,
+                           wxSize(400,25),
+                           wxTE_READONLY,
+                           wxDefaultValidator,
+                           wxT("Cache") );
+  bSizer2->Add( CacheCtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- regclass name
+  RegClassNameText = new wxStaticText(this,
+                                 wxID_ANY,
+                                 wxT("Register Classes"),
+                                 wxDefaultPosition,
+                                 wxDefaultSize,
+                                 0 );
+  RegClassNameText->Wrap(-1);
+  bSizer2->Add( RegClassNameText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- reg classes
+  RegClassCtrl = new wxTextCtrl(this,
+                           wxID_ANY,
+                           wxEmptyString,
+                           wxDefaultPosition,
+                           wxSize(400,100),
+                           wxTE_MULTILINE|wxTE_READONLY,
+                           wxDefaultValidator,
+                           wxT("Reg Classes") );
+  bSizer2->Add( RegClassCtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+  for( unsigned i=0; i<Core->GetNumRegClass(); i++ ){
+    RegClassCtrl->AppendText(wxString(Core->GetRegClass(i)->GetName()));
+  }
+
+  //-- ext name
+  ExtNameText = new wxStaticText(this,
+                             wxID_ANY,
+                             wxT("Extensions"),
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0 );
+  ExtNameText->Wrap(-1);
+  bSizer2->Add( ExtNameText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- ext's
+  ExtCtrl = new wxTextCtrl(this,
+                           wxID_ANY,
+                           wxEmptyString,
+                           wxDefaultPosition,
+                           wxSize(400,100),
+                           wxTE_MULTILINE|wxTE_READONLY,
+                           wxDefaultValidator,
+                           wxT("Extensions") );
+  bSizer2->Add( ExtCtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+  for( unsigned i=0; i<Core->GetNumExt(); i++ ){
+    ExtCtrl->AppendText(wxString(Core->GetExt(i)->GetName()));
+  }
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( this,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  bSizer2->Add( FinalStaticLine, 1, wxSHAPED|wxALL, 5 );
+
+  // setup all the buttons
+  wxBoxSizer *bSizer3 = new wxBoxSizer( wxVERTICAL );
+
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( this, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+
+  bSizer3->Add( m_socbuttonsizer, 1, wxSHAPED, 5 );
+  bSizer2->Add( bSizer3, 1, wxSHAPED, 5 );
+
+  // draw the dialog box until we get more info
+  this->SetSizer( bSizer2 );
+  this->Layout();
+  bSizer2->Fit(this);
+  this->Centre(wxBOTH);
+}
+
+void CoreCoreInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreCoreInfoWin::~CoreCoreInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreCoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreCoreInfoWin.h
@@ -1,0 +1,87 @@
+//
+// _CORECOREINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _CORECOREINFOWIN_H_
+#define _CORECOREINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreCoreInfoWin : public wxDialog {
+public:
+  CoreCoreInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Core Node"),
+                 CoreGenCore *Node = nullptr);
+  ~CoreCoreInfoWin();
+
+  wxStaticText *CoreNameText;     ///< static text for SoC name
+  wxStaticText *ThreadUnitText;   ///< static text for thread units name
+  wxStaticText *ISANameText;      ///< static text for isa name
+  wxStaticText *CacheNameText;    ///< static text for cache name
+  wxStaticText *RegClassNameText; ///< static text for register class name
+  wxStaticText *ExtNameText;      ///< static text for extension name
+
+  wxTextCtrl *CoreNameCtrl;       ///< name of the SoC
+  wxTextCtrl *ThreadUnitCtrl;     ///< number of thread units
+  wxTextCtrl *ISACtrl;            ///< name of the ISA
+  wxTextCtrl *CacheCtrl;          ///< name of the primary cache layer
+  wxTextCtrl *RegClassCtrl;       ///< name of the register classes
+  wxTextCtrl *ExtCtrl;            ///< name of the extensions
+
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxPanel *m_panel1;              ///< main panel
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreDrawInstFormat.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreDrawInstFormat.cpp
@@ -1,0 +1,45 @@
+//
+// _COREDRAWINSTFORMAT_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreDrawInstFormat.h"
+
+wxBEGIN_EVENT_TABLE(CoreDrawInstFormat, wxPanel)
+  EVT_PAINT(CoreDrawInstFormat::paintEvent)
+wxEND_EVENT_TABLE()
+
+CoreDrawInstFormat::CoreDrawInstFormat(wxWindow *parent,
+                                       wxWindowID id,
+                                       const wxString& title,
+                                       CoreGenInstFormat *IF ) :
+  wxPanel(parent, id, wxDefaultPosition, wxDefaultSize,
+          wxTAB_TRAVERSAL, title), IF(IF){
+}
+
+void CoreDrawInstFormat::paintEvent(wxPaintEvent& evt){
+  this->paintNow();
+}
+
+void CoreDrawInstFormat::paintNow(){
+  wxPaintDC *dc = new wxPaintDC(this);
+  wxCoord X;
+  wxCoord Y;
+  dc->GetLogicalOrigin(&X,&Y);
+  dc->DrawText(wxString(IF->GetName()),X,Y);
+#if 0
+  dc->SetBrush(*wxBLUE_BRUSH); // blue filling
+  dc->SetPen( wxPen( wxColor(255,175,175), 10 ) ); // 10-pixels-thick pink outline
+  dc->DrawRectangle( 300, 100, 400, 200 );
+#endif
+}
+
+CoreDrawInstFormat::~CoreDrawInstFormat(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreDrawInstFormat.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreDrawInstFormat.cpp
@@ -33,6 +33,7 @@ void CoreDrawInstFormat::paintNow(){
   dc->GetLogicalOrigin(&X,&Y);
   dc->DrawText(wxString(IF->GetName()),X,Y);
 #if 0
+  // TODO: draw all the rectangles
   dc->SetBrush(*wxBLUE_BRUSH); // blue filling
   dc->SetPen( wxPen( wxColor(255,175,175), 10 ) ); // 10-pixels-thick pink outline
   dc->DrawRectangle( 300, 100, 400, 200 );

--- a/src/CoreGenPortal/PortalCore/CoreDrawInstFormat.h
+++ b/src/CoreGenPortal/PortalCore/CoreDrawInstFormat.h
@@ -1,5 +1,5 @@
 //
-// _COREINFOWIN_H_
+// _COREDRAWINSTFORMAT_H_
 //
 // Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#ifndef _COREINFOWIN_H_
-#define _COREINFOWIN_H_
+#ifndef _COREDRAWINSTFORMAT_H_
+#define _COREDRAWINSTFORMAT_H_
 
 //-- WX HEADERS
 #include <wx/artprov.h>
@@ -33,24 +33,27 @@
 #include <wx/dialog.h>
 #include <wx/checkbox.h>
 #include <wx/msgdlg.h>
-
-//-- PORTAL HEADERS
-#include "CoreGenPortal/PortalCore/CoreSocInfoWin.h"
-#include "CoreGenPortal/PortalCore/CoreCoreInfoWin.h"
-#include "CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h"
+#include <wx/dcclient.h>
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"
 
-class CoreInfoWin{
+class CoreDrawInstFormat : public wxPanel {
 public:
-  CoreInfoWin( wxWindow* parent,
-               wxWindowID id = wxID_ANY,
-               CoreGenNode *Node = nullptr);
-  ~CoreInfoWin();
+  CoreDrawInstFormat( wxWindow *parent,
+                      wxWindowID id = wxID_ANY,
+                      const wxString& title = wxT("Inst Format Figure"),
+                      CoreGenInstFormat *Node = nullptr);
+  ~CoreDrawInstFormat();
+
+  void paintEvent(wxPaintEvent& evt);
+  void paintNow();
+
+  DECLARE_EVENT_TABLE();
 
 protected:
 private:
+  CoreGenInstFormat *IF;    //< handler for the instruction format
 };
 
 #endif

--- a/src/CoreGenPortal/PortalCore/CoreEncodingInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreEncodingInfoWin.cpp
@@ -1,0 +1,163 @@
+//
+// _COREENCODINGINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreEncodingInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreEncodingInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreEncodingInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreEncodingInfoWin::CoreEncodingInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenEncoding *Enc)
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Enc == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- encoding name
+  EncodingNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Encoding Node Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  EncodingNameText->Wrap(-1);
+  InnerSizer->Add( EncodingNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  EncNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Enc->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("EncName") );
+  InnerSizer->Add( EncNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- field name
+  FieldNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Encoding Field"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  FieldNameText->Wrap(-1);
+  InnerSizer->Add( FieldNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  FieldNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Enc->GetField()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("EncField") );
+  InnerSizer->Add( FieldNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- field length
+  FieldLenText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Encoding Length (in bits)"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  FieldLenText->Wrap(-1);
+  InnerSizer->Add( FieldLenText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  FieldLenCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString::Format(wxT("%i"),Enc->GetLength()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("EncLen") );
+  InnerSizer->Add( FieldLenCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- encoding
+  EncText = new wxStaticText( Wnd,
+                              wxID_ANY,
+                              wxT("Encoding"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              0 );
+  EncText->Wrap(-1);
+  InnerSizer->Add( EncText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  wxString tmp = wxString::Format("%" wxLongLongFmtSpec "u",
+                                    Enc->GetEncoding() );
+  EncCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            tmp,
+                            wxDefaultPosition,
+                            wxSize(400,25),
+                            wxTE_READONLY,
+                            wxDefaultValidator,
+                            wxT("Enc") );
+  InnerSizer->Add( EncCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreEncodingInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreEncodingInfoWin::~CoreEncodingInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreEncodingInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreEncodingInfoWin.h
@@ -1,0 +1,87 @@
+//
+// _COREENCODINGINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREENCODINGINFOWIN_H_
+#define _COREENCODINGINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreEncodingInfoWin : public wxDialog {
+public:
+  CoreEncodingInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Inst Node"),
+                 CoreGenEncoding *Node = nullptr);
+  ~CoreEncodingInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *EncodingNameText; ///< static text for encoding name
+  wxStaticText *FieldNameText;    ///< static text for field name
+  wxStaticText *FieldLenText;     ///< static text for field length
+  wxStaticText *EncText;          ///< static text for encoding
+
+  wxTextCtrl *EncNameCtrl;        ///< encoding name
+  wxTextCtrl *FieldNameCtrl;      ///< field name
+  wxTextCtrl *FieldLenCtrl;       ///< field length
+  wxTextCtrl *EncCtrl;            ///< encoding
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreEncodingInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreEncodingInfoWin.h
@@ -43,7 +43,7 @@ class CoreEncodingInfoWin : public wxDialog {
 public:
   CoreEncodingInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Inst Node"),
+                 const wxString& title = wxT("Encoding Node"),
                  CoreGenEncoding *Node = nullptr);
   ~CoreEncodingInfoWin();
 

--- a/src/CoreGenPortal/PortalCore/CoreExtInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreExtInfoWin.cpp
@@ -1,0 +1,137 @@
+//
+// _COREEXTINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreExtInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreExtInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreExtInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreExtInfoWin::CoreExtInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenExt *Ext )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Ext == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- extension name
+  ExtNameText = new wxStaticText( Wnd,
+                                  wxID_ANY,
+                                  wxT("Extension Name"),
+                                  wxDefaultPosition,
+                                  wxDefaultSize,
+                                  0 );
+  ExtNameText->Wrap(-1);
+  InnerSizer->Add( ExtNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  ExtNameCtrl = new wxTextCtrl( Wnd,
+                                wxID_ANY,
+                                wxString(Ext->GetName()),
+                                wxDefaultPosition,
+                                wxSize(400,25),
+                                wxTE_READONLY,
+                                wxDefaultValidator,
+                                wxT("ExtName") );
+  InnerSizer->Add( ExtNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+
+  //-- extension type
+  ExtTypeText = new wxStaticText( Wnd,
+                                  wxID_ANY,
+                                  wxT("Extension Type"),
+                                  wxDefaultPosition,
+                                  wxDefaultSize,
+                                  0 );
+  ExtTypeText->Wrap(-1);
+  InnerSizer->Add( ExtTypeText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  ExtTypeCtrl = new wxTextCtrl( Wnd,
+                                wxID_ANY,
+                                wxEmptyString,
+                                wxDefaultPosition,
+                                wxSize(400,25),
+                                wxTE_READONLY,
+                                wxDefaultValidator,
+                                wxT("ExtType") );
+  switch(Ext->GetType()){
+  case CGExtTemplate:
+    ExtTypeCtrl->AppendText(wxT("Template extension"));
+    break;
+  case CGExtModule:
+    ExtTypeCtrl->AppendText(wxT("Module extension"));
+    break;
+  case CGExtComm:
+    ExtTypeCtrl->AppendText(wxT("Communications extension"));
+    break;
+  case CGExtUnk:
+  default:
+    ExtTypeCtrl->AppendText(wxT("Unknown extension"));
+    break;
+  }
+  InnerSizer->Add( ExtTypeCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreExtInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreExtInfoWin::~CoreExtInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreExtInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreExtInfoWin.h
@@ -1,0 +1,83 @@
+//
+// _COREEXTINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREEXTINFOWIN_H_
+#define _COREEXTINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreExtInfoWin : public wxDialog {
+public:
+  CoreExtInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Inst Node"),
+                 CoreGenExt *Node = nullptr);
+  ~CoreExtInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *ExtNameText;      ///< static text for SoC name
+  wxStaticText *ExtTypeText;      ///< static text for inst format
+
+  wxTextCtrl *ExtNameCtrl;        ///< extension name
+  wxTextCtrl *ExtTypeCtrl;        ///< extension type
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreExtInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreExtInfoWin.h
@@ -43,7 +43,7 @@ class CoreExtInfoWin : public wxDialog {
 public:
   CoreExtInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Inst Node"),
+                 const wxString& title = wxT("Ext Node"),
                  CoreGenExt *Node = nullptr);
   ~CoreExtInfoWin();
 

--- a/src/CoreGenPortal/PortalCore/CoreISAInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreISAInfoWin.cpp
@@ -1,0 +1,101 @@
+//
+// _COREISAINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreISAInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreISAInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreISAInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreISAInfoWin::CoreISAInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenISA *ISA )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( ISA == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  // -- ISA
+  ISANameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("ISA Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  ISANameText->Wrap(-1);
+  InnerSizer->Add( ISANameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  ISANameCtrl = new wxTextCtrl( Wnd,
+                                wxID_ANY,
+                                wxString(ISA->GetName()),
+                                wxDefaultPosition,
+                                wxSize(400,25),
+                                wxTE_READONLY,
+                                wxDefaultValidator,
+                                wxT("ISA Name") );
+  InnerSizer->Add( ISANameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreISAInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreISAInfoWin::~CoreISAInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreISAInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreISAInfoWin.h
@@ -43,7 +43,7 @@ class CoreISAInfoWin : public wxDialog {
 public:
   CoreISAInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Inst Node"),
+                 const wxString& title = wxT("ISA Node"),
                  CoreGenISA *Node = nullptr);
   ~CoreISAInfoWin();
 

--- a/src/CoreGenPortal/PortalCore/CoreISAInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreISAInfoWin.h
@@ -1,0 +1,81 @@
+//
+// _COREISAINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREISAINFOWIN_H_
+#define _COREISAINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreISAInfoWin : public wxDialog {
+public:
+  CoreISAInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Inst Node"),
+                 CoreGenISA *Node = nullptr);
+  ~CoreISAInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *ISANameText;      ///< static text for ISA
+
+  wxTextCtrl *ISANameCtrl;        ///< isa name
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -1,0 +1,43 @@
+//
+// _COREINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreInfoWin.h"
+
+CoreInfoWin::CoreInfoWin( wxWindow *parent,
+                          wxWindowID id,
+                          CoreGenNode *Node ){
+  if( Node->GetType() == CGSoc ){
+    CoreSocInfoWin *Win = new CoreSocInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenSoC *>(Node) );
+    Win->ShowModal();
+    delete Win;
+  }else if( Node->GetType() == CGCore ){
+  }else if( Node->GetType() == CGInstF ){
+  }else if( Node->GetType() == CGInst ){
+  }else if( Node->GetType() == CGPInst ){
+  }else if( Node->GetType() == CGRegC ){
+  }else if( Node->GetType() == CGReg ){
+  }else if( Node->GetType() == CGISA ){
+  }else if( Node->GetType() == CGCache ){
+  }else if( Node->GetType() == CGEnc ){
+  }else if( Node->GetType() == CGExt ){
+  }else if( Node->GetType() == CGComm ){
+  }else if( Node->GetType() == CGSpad ){
+  }else if( Node->GetType() == CGMCtrl ){
+  }else if( Node->GetType() == CGVTP ){
+  }else if( Node->GetType() == CGPlugin ){
+  }
+}
+
+CoreInfoWin::~CoreInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -68,6 +68,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGEnc ){
+    CoreEncodingInfoWin *Win = new CoreEncodingInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenEncoding *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGExt ){
   }else if( Node->GetType() == CGComm ){
   }else if( Node->GetType() == CGSpad ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -20,6 +20,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGCore ){
+    CoreCoreInfoWin *Win = new CoreCoreInfoWin( parent, id,
+                                                wxString(Node->GetName()),
+                                                static_cast<CoreGenCore *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGInstF ){
   }else if( Node->GetType() == CGInst ){
   }else if( Node->GetType() == CGPInst ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -62,6 +62,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGCache ){
+    CoreCacheInfoWin *Win = new CoreCacheInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenCache *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGEnc ){
   }else if( Node->GetType() == CGExt ){
   }else if( Node->GetType() == CGComm ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -74,6 +74,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGExt ){
+    CoreExtInfoWin *Win = new CoreExtInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenExt *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGComm ){
   }else if( Node->GetType() == CGSpad ){
   }else if( Node->GetType() == CGMCtrl ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -86,6 +86,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGSpad ){
+    CoreSpadInfoWin *Win = new CoreSpadInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenSpad *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGMCtrl ){
   }else if( Node->GetType() == CGVTP ){
   }else if( Node->GetType() == CGPlugin ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -44,6 +44,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGRegC ){
+    CoreRegClassInfoWin *Win = new CoreRegClassInfoWin( parent, id,
+                                                  wxString(Node->GetName()),
+                                                  static_cast<CoreGenRegClass *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGReg ){
   }else if( Node->GetType() == CGISA ){
   }else if( Node->GetType() == CGCache ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -32,6 +32,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGInst ){
+    CoreInstInfoWin *Win = new CoreInstInfoWin( parent, id,
+                                                wxString(Node->GetName()),
+                                                static_cast<CoreGenInst *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGPInst ){
   }else if( Node->GetType() == CGRegC ){
   }else if( Node->GetType() == CGReg ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -38,6 +38,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGPInst ){
+    CorePInstInfoWin *Win = new CorePInstInfoWin( parent, id,
+                                                  wxString(Node->GetName()),
+                                                  static_cast<CoreGenPseudoInst *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGRegC ){
   }else if( Node->GetType() == CGReg ){
   }else if( Node->GetType() == CGISA ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -50,6 +50,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGReg ){
+    CoreRegInfoWin *Win = new CoreRegInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenReg *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGISA ){
   }else if( Node->GetType() == CGCache ){
   }else if( Node->GetType() == CGEnc ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -26,6 +26,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGInstF ){
+    CoreInstFormatInfoWin *Win = new CoreInstFormatInfoWin(parent, id,
+                                                           wxString(Node->GetName()),
+                                                           static_cast<CoreGenInstFormat *>(Node));
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGInst ){
   }else if( Node->GetType() == CGPInst ){
   }else if( Node->GetType() == CGRegC ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -98,6 +98,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGVTP ){
+    CoreVTPInfoWin *Win = new CoreVTPInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenVTP *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGPlugin ){
   }
 }

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -92,6 +92,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGMCtrl ){
+    CoreMCtrlInfoWin *Win = new CoreMCtrlInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenMCtrl *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGVTP ){
   }else if( Node->GetType() == CGPlugin ){
   }

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -104,6 +104,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGPlugin ){
+    CorePluginInfoWin *Win = new CorePluginInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenPlugin *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }
 }
 

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -56,6 +56,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGISA ){
+    CoreISAInfoWin *Win = new CoreISAInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenISA *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGCache ){
   }else if( Node->GetType() == CGEnc ){
   }else if( Node->GetType() == CGExt ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.cpp
@@ -80,6 +80,11 @@ CoreInfoWin::CoreInfoWin( wxWindow *parent,
     Win->ShowModal();
     delete Win;
   }else if( Node->GetType() == CGComm ){
+    CoreCommInfoWin *Win = new CoreCommInfoWin( parent, id,
+                                              wxString(Node->GetName()),
+                                              static_cast<CoreGenComm *>(Node) );
+    Win->ShowModal();
+    delete Win;
   }else if( Node->GetType() == CGSpad ){
   }else if( Node->GetType() == CGMCtrl ){
   }else if( Node->GetType() == CGVTP ){

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -42,6 +42,7 @@
 #include "CoreGenPortal/PortalCore/CorePInstInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreRegClassInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreRegInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreISAInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -49,6 +49,7 @@
 #include "CoreGenPortal/PortalCore/CoreCommInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreSpadInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreMCtrlInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreVTPInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -41,6 +41,7 @@
 #include "CoreGenPortal/PortalCore/CoreInstInfoWin.h"
 #include "CoreGenPortal/PortalCore/CorePInstInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreRegClassInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreRegInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -48,6 +48,7 @@
 #include "CoreGenPortal/PortalCore/CoreExtInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreCommInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreSpadInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreMCtrlInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -38,6 +38,7 @@
 #include "CoreGenPortal/PortalCore/CoreSocInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreCoreInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreInstInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -46,6 +46,7 @@
 #include "CoreGenPortal/PortalCore/CoreCacheInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreEncodingInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreExtInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreCommInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -43,6 +43,7 @@
 #include "CoreGenPortal/PortalCore/CoreRegClassInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreRegInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreISAInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreCacheInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -36,6 +36,7 @@
 
 //-- PORTAL HEADERS
 #include "CoreGenPortal/PortalCore/CoreSocInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreCoreInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -45,6 +45,7 @@
 #include "CoreGenPortal/PortalCore/CoreISAInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreCacheInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreEncodingInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreExtInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -50,6 +50,7 @@
 #include "CoreGenPortal/PortalCore/CoreSpadInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreMCtrlInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreVTPInfoWin.h"
+#include "CoreGenPortal/PortalCore/CorePluginInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -40,6 +40,7 @@
 #include "CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreInstInfoWin.h"
 #include "CoreGenPortal/PortalCore/CorePInstInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreRegClassInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -47,6 +47,7 @@
 #include "CoreGenPortal/PortalCore/CoreEncodingInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreExtInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreCommInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreSpadInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -39,6 +39,7 @@
 #include "CoreGenPortal/PortalCore/CoreCoreInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreInstInfoWin.h"
+#include "CoreGenPortal/PortalCore/CorePInstInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -1,0 +1,56 @@
+//
+// _COREINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREINFOWIN_H_
+#define _COREINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+
+//-- PORTAL HEADERS
+#include "CoreGenPortal/PortalCore/CoreSocInfoWin.h"
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreInfoWin{
+public:
+  CoreInfoWin( wxWindow* parent,
+               wxWindowID id = wxID_ANY,
+               CoreGenNode *Node = nullptr);
+  ~CoreInfoWin();
+
+protected:
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInfoWin.h
@@ -44,6 +44,7 @@
 #include "CoreGenPortal/PortalCore/CoreRegInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreISAInfoWin.h"
 #include "CoreGenPortal/PortalCore/CoreCacheInfoWin.h"
+#include "CoreGenPortal/PortalCore/CoreEncodingInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"

--- a/src/CoreGenPortal/PortalCore/CoreInstFormatInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInstFormatInfoWin.cpp
@@ -1,0 +1,77 @@
+//
+// _COREINSTFORMATINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreInstFormatInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreInstFormatInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreInstFormatInfoWin::CoreInstFormatInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenInstFormat *InstF )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxVSCROLL|wxFULL_REPAINT_ON_RESIZE ){
+  if( InstF == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  //this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  //-- inst format figure
+  IFDraw = new CoreDrawInstFormat( this,
+                                   wxID_ANY,
+                                   wxT("Inst Format Figure"),
+                                   InstF );
+  IFDraw->SetAutoLayout(true);
+  IFDraw->Layout();
+  InnerSizer->Add( IFDraw, 1, wxALIGN_CENTER|wxALL|wxEXPAND, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( this,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND|wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( this, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  // draw everything
+  OuterSizer->Add(InnerSizer,1,wxEXPAND,5);
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout(true);
+  this->Layout();
+}
+
+void CoreInstFormatInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreInstFormatInfoWin::~CoreInstFormatInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h
@@ -45,7 +45,7 @@ class CoreInstFormatInfoWin : public wxDialog {
 public:
   CoreInstFormatInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Core Node"),
+                 const wxString& title = wxT("Inst Format Node"),
                  CoreGenInstFormat *Node = nullptr);
   ~CoreInstFormatInfoWin();
 

--- a/src/CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInstFormatInfoWin.h
@@ -1,0 +1,82 @@
+//
+// _COREINSTFORMATINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREINSTFORMATINFOWIN_H_
+#define _COREINSTFORMATINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+
+//-- PORTAL HEADERS
+#include "CoreGenPortal/PortalCore/CoreDrawInstFormat.h"
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreInstFormatInfoWin : public wxDialog {
+public:
+  CoreInstFormatInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Core Node"),
+                 CoreGenInstFormat *Node = nullptr);
+  ~CoreInstFormatInfoWin();
+
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxPanel *m_panel1;              ///< main panel
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  // standard sizers
+  wxBoxSizer *OuterSizer;     ///< outer box sizer
+  wxBoxSizer *InnerSizer;     ///< inner box sizer
+
+  CoreDrawInstFormat *IFDraw; ///< inst format drawing object
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreInstInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInstInfoWin.cpp
@@ -1,0 +1,208 @@
+//
+// _COREINSTINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreInstInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreInstInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreInstInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenInst *Inst )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Inst == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- inst name
+  InstNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Instruction Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  InstNameText->Wrap(-1);
+  InnerSizer->Add( InstNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  InstNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Inst->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("Inst Name") );
+  InnerSizer->Add( InstNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- inst format
+  InstFNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Instruction Format"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  InstFNameText->Wrap(-1);
+  InnerSizer->Add( InstFNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  InstFNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Inst->GetFormat()->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("Inst Format Name") );
+  InnerSizer->Add( InstFNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- isa name
+  ISANameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Instruction Set"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  ISANameText->Wrap(-1);
+  InnerSizer->Add( ISANameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  ISANameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Inst->GetISA()->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("Inst Format Name") );
+  InnerSizer->Add( ISANameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- syntax
+  SyntaxText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Syntax"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  SyntaxText->Wrap(-1);
+  InnerSizer->Add( SyntaxText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  SyntaxCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Inst->GetSyntax()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("Inst Format Name") );
+  InnerSizer->Add( SyntaxCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- stone cutter implementation
+  StoneCText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("StoneCutter Syntax"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  StoneCText->Wrap(-1);
+  InnerSizer->Add( StoneCText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  StoneCCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Inst->GetImpl()),
+                                 wxDefaultPosition,
+                                 wxSize(400,100),
+                                 wxTE_READONLY|wxTE_MULTILINE|wxHSCROLL,
+                                 wxDefaultValidator,
+                                 wxT("StoneCutter") );
+  InnerSizer->Add( StoneCCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- encodings
+  EncText = new wxStaticText( Wnd,
+                              wxID_ANY,
+                              wxT("Instruction Field Encodings"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              0 );
+  EncText->Wrap(-1);
+  InnerSizer->Add( EncText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  EncCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxString(Inst->GetImpl()),
+                            wxDefaultPosition,
+                            wxSize(400,100),
+                            wxTE_READONLY|wxTE_MULTILINE|wxHSCROLL,
+                            wxDefaultValidator,
+                            wxT("StoneCutter") );
+
+  for( unsigned i=0; i<Inst->GetNumEncodings(); i++ ){
+    wxString tmp = wxString::Format("%" wxLongLongFmtSpec "u",
+                                    Inst->GetEncoding(i)->GetEncoding() );
+    EncCtrl->AppendText(wxString(Inst->GetEncoding(i)->GetField()) +
+                        wxT(" = ") + tmp );
+  }
+  InnerSizer->Add( EncCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreInstInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreInstInfoWin::~CoreInstInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreInstInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreInstInfoWin.cpp
@@ -167,7 +167,7 @@ CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
     wxString tmp = wxString::Format("%" wxLongLongFmtSpec "u",
                                     Inst->GetEncoding(i)->GetEncoding() );
     EncCtrl->AppendText(wxString(Inst->GetEncoding(i)->GetField()) +
-                        wxT(" = ") + tmp );
+                        wxT(" = ") + tmp + wxT("\n"));
   }
   InnerSizer->Add( EncCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
 

--- a/src/CoreGenPortal/PortalCore/CoreInstInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreInstInfoWin.h
@@ -1,5 +1,5 @@
 //
-// _CORECOREINFOWIN_H_
+// _COREINSTINFOWIN_H_
 //
 // Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#ifndef _CORECOREINFOWIN_H_
-#define _CORECOREINFOWIN_H_
+#ifndef _COREINSTINFOWIN_H_
+#define _COREINSTINFOWIN_H_
 
 //-- WX HEADERS
 #include <wx/artprov.h>
@@ -34,17 +34,18 @@
 #include <wx/checkbox.h>
 #include <wx/msgdlg.h>
 #include <wx/textctrl.h>
+#include <wx/scrolwin.h>
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"
 
-class CoreCoreInfoWin : public wxDialog {
+class CoreInstInfoWin : public wxDialog {
 public:
-  CoreCoreInfoWin( wxWindow* parent,
+  CoreInstInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Core Node"),
-                 CoreGenCore *Node = nullptr);
-  ~CoreCoreInfoWin();
+                 const wxString& title = wxT("Inst Node"),
+                 CoreGenInst *Node = nullptr);
+  ~CoreInstInfoWin();
 
   // Event handler functions
   /// Declares the event table
@@ -55,24 +56,28 @@ public:
 
 protected:
   // window handlers
-  wxPanel *m_panel1;              ///< main panel
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
 
   // static lines
   wxStaticLine* FinalStaticLine;  ///< final static line
 
-  wxStaticText *CoreNameText;     ///< static text for SoC name
-  wxStaticText *ThreadUnitText;   ///< static text for thread units name
-  wxStaticText *ISANameText;      ///< static text for isa name
-  wxStaticText *CacheNameText;    ///< static text for cache name
-  wxStaticText *RegClassNameText; ///< static text for register class name
-  wxStaticText *ExtNameText;      ///< static text for extension name
+  wxStaticText *InstNameText;     ///< static text for SoC name
+  wxStaticText *InstFNameText;    ///< static text for inst format
+  wxStaticText *ISANameText;      ///< static text for isa format
+  wxStaticText *SyntaxText;       ///< static text for syntax
+  wxStaticText *StoneCText;       ///< static text for stonecutter
+  wxStaticText *EncText;          ///< static text for encodings
 
-  wxTextCtrl *CoreNameCtrl;       ///< name of the SoC
-  wxTextCtrl *ThreadUnitCtrl;     ///< number of thread units
-  wxTextCtrl *ISACtrl;            ///< name of the ISA
-  wxTextCtrl *CacheCtrl;          ///< name of the primary cache layer
-  wxTextCtrl *RegClassCtrl;       ///< name of the register classes
-  wxTextCtrl *ExtCtrl;            ///< name of the extensions
+  wxTextCtrl *InstNameCtrl;       ///< instruction name
+  wxTextCtrl *InstFNameCtrl;      ///< instruction format name
+  wxTextCtrl *ISANameCtrl;        ///< instruction set name
+  wxTextCtrl *SyntaxCtrl;         ///< instruction syntax (asm)
+  wxTextCtrl *StoneCCtrl;         ///< StoneCutter syntax
+  wxTextCtrl *EncCtrl;            ///< StoneCutter syntax
 
   // buttons
   wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer

--- a/src/CoreGenPortal/PortalCore/CoreMCtrlInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreMCtrlInfoWin.cpp
@@ -1,0 +1,121 @@
+//
+// _COREMCTRLINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreMCtrlInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreMCtrlInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreMCtrlInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreMCtrlInfoWin::CoreMCtrlInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenMCtrl *MCtrl )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( MCtrl == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- memory controller name
+  MCtrlNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Memory Controller Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  MCtrlNameText->Wrap(-1);
+  InnerSizer->Add( MCtrlNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  MCtrlCtrl = new wxTextCtrl( Wnd,
+                              wxID_ANY,
+                              wxString(MCtrl->GetName()),
+                              wxDefaultPosition,
+                              wxSize(400,25),
+                              wxTE_READONLY,
+                              wxDefaultValidator,
+                              wxT("MCtrlName") );
+  InnerSizer->Add( MCtrlCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- input ports
+  InputPortText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Input Ports"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  InputPortText->Wrap(-1);
+  InnerSizer->Add( InputPortText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  InputPortCtrl = new wxTextCtrl( Wnd,
+                                  wxID_ANY,
+                                  wxString::Format(wxT("%i"),MCtrl->GetNumInputPorts()),
+                                  wxDefaultPosition,
+                                  wxSize(400,25),
+                                  wxTE_READONLY,
+                                  wxDefaultValidator,
+                                  wxT("InputPorts") );
+  InnerSizer->Add( InputPortCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreMCtrlInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreMCtrlInfoWin::~CoreMCtrlInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreMCtrlInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreMCtrlInfoWin.h
@@ -1,0 +1,83 @@
+//
+// _COREMCTRLINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREMCTRLINFOWIN_H_
+#define _COREMCTRLINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreMCtrlInfoWin : public wxDialog {
+public:
+  CoreMCtrlInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Memory Controller Node"),
+                 CoreGenMCtrl *Node = nullptr);
+  ~CoreMCtrlInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *MCtrlNameText;    ///< static text for spad name
+  wxStaticText *InputPortText;    ///< static text for input ports
+
+  wxTextCtrl *MCtrlCtrl;          ///< memory controller name
+  wxTextCtrl *InputPortCtrl;      ///< input ports for memory controller
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CorePInstInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CorePInstInfoWin.cpp
@@ -1,5 +1,5 @@
 //
-// _COREINSTINFOWIN_CPP_
+// _COREPINSTINFOWIN_CPP_
 //
 // Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -8,20 +8,20 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "CoreGenPortal/PortalCore/CoreInstInfoWin.h"
+#include "CoreGenPortal/PortalCore/CorePInstInfoWin.h"
 
 // Event Table
-wxBEGIN_EVENT_TABLE(CoreInstInfoWin, wxDialog)
-  EVT_BUTTON(wxID_OK, CoreInstInfoWin::OnPressOk)
+wxBEGIN_EVENT_TABLE(CorePInstInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CorePInstInfoWin::OnPressOk)
 wxEND_EVENT_TABLE()
 
-CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
+CorePInstInfoWin::CorePInstInfoWin( wxWindow* parent,
                               wxWindowID id,
                               const wxString& title,
-                              CoreGenInst *Inst )
+                              CoreGenPseudoInst *PInst )
   : wxDialog( parent, id, title, wxDefaultPosition,
               wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
-  if( Inst == nullptr ){
+  if( PInst == nullptr ){
     this->EndModal(wxID_OK);
   }
 
@@ -44,10 +44,30 @@ CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
   InnerSizer = new wxBoxSizer( wxVERTICAL );
 
   // add all the interior data
+  //-- pseudo inst name
+  PInstNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Pseudo Instruction Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  PInstNameText->Wrap(-1);
+  InnerSizer->Add( PInstNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  PInstNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(PInst->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("Inst Name") );
+  InnerSizer->Add( PInstNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
   //-- inst name
   InstNameText = new wxStaticText( Wnd,
                                    wxID_ANY,
-                                   wxT("Instruction Name"),
+                                   wxT("Target Instruction Name"),
                                    wxDefaultPosition,
                                    wxDefaultSize,
                                    0 );
@@ -56,33 +76,13 @@ CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
 
   InstNameCtrl = new wxTextCtrl( Wnd,
                                  wxID_ANY,
-                                 wxString(Inst->GetName()),
+                                 wxString(PInst->GetInst()->GetName()),
                                  wxDefaultPosition,
                                  wxSize(400,25),
                                  wxTE_READONLY,
                                  wxDefaultValidator,
                                  wxT("Inst Name") );
   InnerSizer->Add( InstNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
-
-  //-- inst format
-  InstFNameText = new wxStaticText( Wnd,
-                                   wxID_ANY,
-                                   wxT("Instruction Format"),
-                                   wxDefaultPosition,
-                                   wxDefaultSize,
-                                   0 );
-  InstFNameText->Wrap(-1);
-  InnerSizer->Add( InstFNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
-
-  InstFNameCtrl = new wxTextCtrl( Wnd,
-                                 wxID_ANY,
-                                 wxString(Inst->GetFormat()->GetName()),
-                                 wxDefaultPosition,
-                                 wxSize(400,25),
-                                 wxTE_READONLY,
-                                 wxDefaultValidator,
-                                 wxT("Inst Format Name") );
-  InnerSizer->Add( InstFNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
 
   //-- isa name
   ISANameText = new wxStaticText( Wnd,
@@ -96,53 +96,13 @@ CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
 
   ISANameCtrl = new wxTextCtrl( Wnd,
                                  wxID_ANY,
-                                 wxString(Inst->GetISA()->GetName()),
+                                 wxString(PInst->GetISA()->GetName()),
                                  wxDefaultPosition,
                                  wxSize(400,25),
                                  wxTE_READONLY,
                                  wxDefaultValidator,
                                  wxT("Inst Format Name") );
   InnerSizer->Add( ISANameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
-
-  //-- syntax
-  SyntaxText = new wxStaticText( Wnd,
-                                   wxID_ANY,
-                                   wxT("Syntax"),
-                                   wxDefaultPosition,
-                                   wxDefaultSize,
-                                   0 );
-  SyntaxText->Wrap(-1);
-  InnerSizer->Add( SyntaxText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
-
-  SyntaxCtrl = new wxTextCtrl( Wnd,
-                                 wxID_ANY,
-                                 wxString(Inst->GetSyntax()),
-                                 wxDefaultPosition,
-                                 wxSize(400,25),
-                                 wxTE_READONLY,
-                                 wxDefaultValidator,
-                                 wxT("Inst Format Name") );
-  InnerSizer->Add( SyntaxCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
-
-  //-- stone cutter implementation
-  StoneCText = new wxStaticText( Wnd,
-                                   wxID_ANY,
-                                   wxT("StoneCutter Syntax"),
-                                   wxDefaultPosition,
-                                   wxDefaultSize,
-                                   0 );
-  StoneCText->Wrap(-1);
-  InnerSizer->Add( StoneCText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
-
-  StoneCCtrl = new wxTextCtrl( Wnd,
-                                 wxID_ANY,
-                                 wxString(Inst->GetImpl()),
-                                 wxDefaultPosition,
-                                 wxSize(400,100),
-                                 wxTE_READONLY|wxTE_MULTILINE|wxHSCROLL,
-                                 wxDefaultValidator,
-                                 wxT("StoneCutter") );
-  InnerSizer->Add( StoneCCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
 
   //-- encodings
   EncText = new wxStaticText( Wnd,
@@ -163,10 +123,10 @@ CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
                             wxDefaultValidator,
                             wxT("StoneCutter") );
 
-  for( unsigned i=0; i<Inst->GetNumEncodings(); i++ ){
+  for( unsigned i=0; i<PInst->GetNumEncodings(); i++ ){
     wxString tmp = wxString::Format("%" wxLongLongFmtSpec "u",
-                                    Inst->GetEncoding(i)->GetEncoding() );
-    EncCtrl->AppendText(wxString(Inst->GetEncoding(i)->GetField()) +
+                                    PInst->GetEncoding(i)->GetEncoding() );
+    EncCtrl->AppendText(wxString(PInst->GetEncoding(i)->GetField()) +
                         wxT(" = ") + tmp );
   }
   InnerSizer->Add( EncCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
@@ -198,11 +158,11 @@ CoreInstInfoWin::CoreInstInfoWin( wxWindow* parent,
   this->Layout();
 }
 
-void CoreInstInfoWin::OnPressOk(wxCommandEvent& ok){
+void CorePInstInfoWin::OnPressOk(wxCommandEvent& ok){
   this->EndModal(wxID_OK);
 }
 
-CoreInstInfoWin::~CoreInstInfoWin(){
+CorePInstInfoWin::~CorePInstInfoWin(){
 }
 
 // EOF

--- a/src/CoreGenPortal/PortalCore/CorePInstInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CorePInstInfoWin.cpp
@@ -127,7 +127,7 @@ CorePInstInfoWin::CorePInstInfoWin( wxWindow* parent,
     wxString tmp = wxString::Format("%" wxLongLongFmtSpec "u",
                                     PInst->GetEncoding(i)->GetEncoding() );
     EncCtrl->AppendText(wxString(PInst->GetEncoding(i)->GetField()) +
-                        wxT(" = ") + tmp );
+                        wxT(" = ") + tmp + wxT("\n"));
   }
   InnerSizer->Add( EncCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
 

--- a/src/CoreGenPortal/PortalCore/CorePInstInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CorePInstInfoWin.h
@@ -1,0 +1,87 @@
+//
+// _COREPINSTINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREPINSTINFOWIN_H_
+#define _COREPINSTINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CorePInstInfoWin : public wxDialog {
+public:
+  CorePInstInfoWin( wxWindow* parent,
+                    wxWindowID id = wxID_ANY,
+                    const wxString& title = wxT("Pseudo Inst Node"),
+                    CoreGenPseudoInst *Node = nullptr);
+  ~CorePInstInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *PInstNameText;    ///< static text for SoC name
+  wxStaticText *InstNameText;     ///< static text for SoC name
+  wxStaticText *ISANameText;      ///< static text for isa format
+  wxStaticText *EncText;          ///< static text for encodings
+
+  wxTextCtrl *PInstNameCtrl;      ///< instruction name
+  wxTextCtrl *InstNameCtrl;       ///< instruction name
+  wxTextCtrl *ISANameCtrl;        ///< instruction set name
+  wxTextCtrl *EncCtrl;            ///< StoneCutter syntax
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CorePluginInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CorePluginInfoWin.cpp
@@ -1,0 +1,274 @@
+//
+// _COREPLUGININFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CorePluginInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CorePluginInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CorePluginInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CorePluginInfoWin::CorePluginInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenPlugin *Plugin)
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Plugin == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- plugin name
+  PluginNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Plugin Node Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  PluginNameText->Wrap(-1);
+  InnerSizer->Add( PluginNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  PluginNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Plugin->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("PluginName") );
+  InnerSizer->Add( PluginNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- library name
+  LibNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Library Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  LibNameText->Wrap(-1);
+  InnerSizer->Add( LibNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  LibNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Plugin->GetPluginName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("LibName") );
+  InnerSizer->Add( LibNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- version info
+  VersionText = new wxStaticText( Wnd,
+                                  wxID_ANY,
+                                  wxT("Version"),
+                                  wxDefaultPosition,
+                                  wxDefaultSize,
+                                  0 );
+  VersionText->Wrap(-1);
+  InnerSizer->Add( VersionText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  unsigned Major = 0;
+  unsigned Minor = 0;
+  unsigned Patch = 0;
+  Plugin->GetVersion(&Major,&Minor,&Patch);
+  wxString VersionInfo = wxString::Format(wxT("%i"),Major) + wxT(".") +
+                         wxString::Format(wxT("%i"),Minor) + wxT(".") +
+                         wxString::Format(wxT("%i"),Patch);
+  VersionCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 VersionInfo,
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("LibName") );
+  InnerSizer->Add( VersionCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- feature box
+  FeatureText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Plugin Features"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  FeatureText->Wrap(-1);
+  InnerSizer->Add( FeatureText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  FeatureCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxEmptyString,
+                                 wxDefaultPosition,
+                                 wxSize(400,100),
+                                 wxTE_READONLY|wxTE_MULTILINE|wxHSCROLL,
+                                 wxDefaultValidator,
+                                 wxT("Features") );
+  FeatureCtrl->AppendText(wxT("FEATURE_NAME:FEATURE_TYPE:FEATURE_VALUE\n"));
+  for( unsigned i=0; i<Plugin->GetNumFeatures(); i++ ){
+    FeatureCtrl->AppendText(GetFeatureStr(Plugin,i));
+  }
+
+  InnerSizer->Add( FeatureCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- HDL codegen
+  HDLCodegen = new wxCheckBox( Wnd,
+                               wxID_ANY,
+                               wxT("HDL Code Generation"),
+                               wxDefaultPosition,
+                               wxDefaultSize,
+                               wxALIGN_RIGHT,
+                               wxDefaultValidator,
+                               wxT("HDLCodegen") );
+  if( Plugin->HasHDLCodegen() )
+    HDLCodegen->SetValue(true);
+  else
+    HDLCodegen->SetValue(false);
+
+  //-- LLVM codegen
+  LLVMCodegen = new wxCheckBox( Wnd,
+                               wxID_ANY,
+                               wxT("LLVM Code Generation"),
+                               wxDefaultPosition,
+                               wxDefaultSize,
+                               wxALIGN_RIGHT,
+                               wxDefaultValidator,
+                               wxT("LLVMCodegen") );
+  if( Plugin->HasLLVMCodegen() )
+    LLVMCodegen->SetValue(true);
+  else
+    LLVMCodegen->SetValue(false);
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CorePluginInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+wxString CorePluginInfoWin::GetFeatureStr( CoreGenPlugin *Plugin,
+                                           unsigned Idx ){
+  // Name:Type:Value
+  // name
+  wxString FeatureName(Plugin->GetFeatureName(Idx));
+
+  // type & value
+  wxString FeatureType;
+  wxString FeatureValue;
+  CGFeatureVal Value;
+
+  switch( Plugin->GetFeatureType(Idx) ){
+  case CGFUnsigned:
+    FeatureType = wxT("unsigned");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString::Format(wxT("%i"),Value.UnsignedData);
+    break;
+  case CGFUin32t:
+    FeatureType = wxT("uint32_t");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString::Format(wxT("%i"),Value.Uint32tData);
+    break;
+  case CGFint32t:
+    FeatureType = wxT("int32_t");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString::Format(wxT("%i"),Value.Int32tData);
+    break;
+  case CGFUint64t:
+    FeatureType = wxT("uint64_t");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString::Format("%" wxLongLongFmtSpec "u", Value.Uint64tData);
+    break;
+  case CGFInt64t:
+    FeatureType = wxT("int64_t");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString::Format("%" wxLongLongFmtSpec "u", Value.Int64tData);
+    break;
+  case CGFFloat:
+    FeatureType = wxT("float");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString::Format(wxT("%f"),Value.FloatData);
+    break;
+  case CGFDouble:
+    FeatureType = wxT("double");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString::Format(wxT("%f"),Value.DoubleData);
+    break;
+  case CGFString:
+    FeatureType = wxT("string");
+    Value = Plugin->GetFeatureValue(Idx);
+    FeatureValue = wxString(Value.StringData);
+    break;
+  case CGFBool:
+    FeatureType = wxT("bool");
+    Value = Plugin->GetFeatureValue(Idx);
+    if( Value.BoolData )
+      FeatureValue = wxT("true");
+    else
+      FeatureValue = wxT("false");
+    break;
+  case CGFUnknown:
+  default:
+    FeatureType = wxT("unknown");
+    FeatureValue = wxT("unknown");
+    break;
+  }
+
+  wxString Final = FeatureName + wxT(":") +
+                   FeatureType + wxT(":") +
+                   FeatureValue + wxT("\n");
+  return Final;
+}
+
+CorePluginInfoWin::~CorePluginInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CorePluginInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CorePluginInfoWin.h
@@ -1,0 +1,91 @@
+//
+// _COREPLUGININFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREPLUGININFOWIN_H_
+#define _COREPLUGININFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CorePluginInfoWin : public wxDialog {
+public:
+  CorePluginInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Scratchpad Node"),
+                 CoreGenPlugin *Node = nullptr);
+  ~CorePluginInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *PluginNameText;   ///< static text for plugin name
+  wxStaticText *LibNameText;      ///< static text for lib name
+  wxStaticText *VersionText;      ///< static text for version name
+  wxStaticText *FeatureText;      ///< static text for feature name
+
+  wxTextCtrl *PluginNameCtrl;     ///< plugin name
+  wxTextCtrl *LibNameCtrl;        ///< library name
+  wxTextCtrl *VersionCtrl;        ///< version number
+  wxTextCtrl *FeatureCtrl;        ///< features
+
+  wxCheckBox *HDLCodegen;         ///< does this have an HDL codegen?
+  wxCheckBox *LLVMCodegen;        ///< does this have an LLVM codegen?
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+  wxString GetFeatureStr(CoreGenPlugin *Plugin, unsigned i);
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreRegClassInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreRegClassInfoWin.cpp
@@ -1,0 +1,125 @@
+//
+// _COREREGCLASSINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreRegClassInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreRegClassInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreRegClassInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreRegClassInfoWin::CoreRegClassInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenRegClass *RegClass )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( RegClass == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  // -- reg class
+  RegClassNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Register Class Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  RegClassNameText->Wrap(-1);
+  InnerSizer->Add( RegClassNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  RegClassNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(RegClass->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("Reg Class Name") );
+  InnerSizer->Add( RegClassNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- registers
+  RegNameText = new wxStaticText( Wnd,
+                              wxID_ANY,
+                              wxT("Registers"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              0 );
+  RegNameText->Wrap(-1);
+  InnerSizer->Add( RegNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  RegNameCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxEmptyString,
+                            wxDefaultPosition,
+                            wxSize(400,100),
+                            wxTE_READONLY|wxTE_MULTILINE|wxHSCROLL,
+                            wxDefaultValidator,
+                            wxT("registers") );
+
+  for( unsigned i=0; i<RegClass->GetNumReg(); i++ ){
+    RegNameCtrl->AppendText(wxString(RegClass->GetReg(i)->GetName())+wxT("\n") );
+  }
+  InnerSizer->Add( RegNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreRegClassInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreRegClassInfoWin::~CoreRegClassInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreRegClassInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreRegClassInfoWin.h
@@ -43,7 +43,7 @@ class CoreRegClassInfoWin : public wxDialog {
 public:
   CoreRegClassInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Inst Node"),
+                 const wxString& title = wxT("RegClass Node"),
                  CoreGenRegClass *Node = nullptr);
   ~CoreRegClassInfoWin();
 

--- a/src/CoreGenPortal/PortalCore/CoreRegClassInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreRegClassInfoWin.h
@@ -1,0 +1,83 @@
+//
+// _COREREGCLASSINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREREGCLASSINFOWIN_H_
+#define _COREREGCLASSINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreRegClassInfoWin : public wxDialog {
+public:
+  CoreRegClassInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Inst Node"),
+                 CoreGenRegClass *Node = nullptr);
+  ~CoreRegClassInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *RegClassNameText; ///< static text for SoC name
+  wxStaticText *RegNameText;      ///< static text for inst format
+
+  wxTextCtrl *RegClassNameCtrl;   ///< instruction name
+  wxTextCtrl *RegNameCtrl;        ///< instruction format name
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreRegInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreRegInfoWin.cpp
@@ -1,0 +1,300 @@
+//
+// _COREREGINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreRegInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreRegInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreRegInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreRegInfoWin::CoreRegInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenReg *Reg )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Reg == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  // -- reg name
+  RegNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Register Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  RegNameText->Wrap(-1);
+  InnerSizer->Add( RegNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  RegNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Reg->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("Reg Name") );
+  InnerSizer->Add( RegNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- reg idx
+  RegIdxText = new wxStaticText( Wnd,
+                              wxID_ANY,
+                              wxT("Register Index"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              0 );
+  RegIdxText->Wrap(-1);
+  InnerSizer->Add( RegIdxText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  RegIdxCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxString::Format(wxT("%i"),Reg->GetIndex()),
+                            wxDefaultPosition,
+                            wxSize(400,25),
+                            wxTE_READONLY,
+                            wxDefaultValidator,
+                            wxT("Register Index") );
+  InnerSizer->Add( RegIdxCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- width
+  WidthText = new wxStaticText( Wnd,
+                              wxID_ANY,
+                              wxT("Register Width (in bits)"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              0 );
+  WidthText->Wrap(-1);
+  InnerSizer->Add( WidthText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  WidthCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxString::Format(wxT("%i"),Reg->GetWidth()),
+                            wxDefaultPosition,
+                            wxSize(400,25),
+                            wxTE_READONLY,
+                            wxDefaultValidator,
+                            wxT("Register Width") );
+  InnerSizer->Add( WidthCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- subregs
+  SubRegText = new wxStaticText( Wnd,
+                              wxID_ANY,
+                              wxT("Subregister Fields"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              0 );
+  WidthText->Wrap(-1);
+  InnerSizer->Add( SubRegText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  SubRegCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxEmptyString,
+                            wxDefaultPosition,
+                            wxSize(400,100),
+                            wxTE_READONLY|wxTE_MULTILINE|wxHSCROLL,
+                            wxDefaultValidator,
+                            wxT("Subregisters ") );
+  SubRegCtrl->AppendText(wxT("NAME:START_BIT:END_BIT\n"));
+  std::string SRName;
+  unsigned SRStart;
+  unsigned SREnd;
+  for( unsigned i=0; i<Reg->GetNumSubRegs(); i++ ){
+    Reg->GetSubReg(i,SRName,SRStart,SREnd);
+    SubRegCtrl->AppendText(wxString(SRName) + wxT(":") +
+                           wxString::Format(wxT("%i"),SRStart) + wxT(":") +
+                           wxString::Format(wxT("%i"),SREnd) + wxT("\n") );
+  }
+  InnerSizer->Add( SubRegCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- simd check box
+  SIMDCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("SIMD Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("SIMDREGISTER") );
+  if( Reg->IsSIMD() )
+    SIMDCheck->SetValue(true);
+  else
+    SIMDCheck->SetValue(false);
+
+  InnerSizer->Add(SIMDCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+  //-- rw check box
+  RWCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("Read/Write Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("RWREGISTER") );
+  if( Reg->IsRWAttr() )
+    RWCheck->SetValue(true);
+  else
+    RWCheck->SetValue(false);
+
+  InnerSizer->Add(RWCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+  //-- ro check box
+  ROCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("Read-Only Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("ROREGISTER") );
+  if( Reg->IsROAttr() )
+    ROCheck->SetValue(true);
+  else
+    ROCheck->SetValue(false);
+
+  InnerSizer->Add(ROCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+  //-- csr check box
+  CSRCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("Configuration Status Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("CSRREGISTER") );
+  if( Reg->IsCSRAttr() )
+    CSRCheck->SetValue(true);
+  else
+    CSRCheck->SetValue(false);
+
+  InnerSizer->Add(CSRCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+  //-- ams check box
+  AMSCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("Arithmetic Machine State Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("AMSREGISTER") );
+  if( Reg->IsAMSAttr() )
+    AMSCheck->SetValue(true);
+  else
+    AMSCheck->SetValue(false);
+
+  InnerSizer->Add(AMSCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+  //-- tus check box
+  TUSCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("Thread Unit Shared Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("TUSREGISTER") );
+  if( Reg->IsTUSAttr() )
+    TUSCheck->SetValue(true);
+  else
+    TUSCheck->SetValue(false);
+
+  InnerSizer->Add(TUSCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+  //-- pc check box
+  PCCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("PC Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("PCREGISTER") );
+  if( Reg->IsPCAttr() )
+    PCCheck->SetValue(true);
+  else
+    PCCheck->SetValue(false);
+
+  InnerSizer->Add(PCCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+  //-- shared check box
+  SharedCheck = new wxCheckBox( Wnd,
+                              wxID_ANY,
+                              wxT("Shared Register"),
+                              wxDefaultPosition,
+                              wxDefaultSize,
+                              wxALIGN_RIGHT,
+                              wxDefaultValidator,
+                              wxT("SHAREDREGISTER") );
+  if( Reg->IsShared() )
+    SharedCheck->SetValue(true);
+  else
+    SharedCheck->SetValue(false);
+
+  InnerSizer->Add(SharedCheck, 1, wxEXPAND|wxALIGN_LEFT|wxALL, 5);
+
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreRegInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreRegInfoWin::~CoreRegInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreRegInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreRegInfoWin.h
@@ -1,0 +1,96 @@
+//
+// _COREREGINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _COREREGINFOWIN_H_
+#define _COREREGINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreRegInfoWin : public wxDialog {
+public:
+  CoreRegInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Inst Node"),
+                 CoreGenReg *Node = nullptr);
+  ~CoreRegInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *RegNameText;      ///< static text for reg name
+  wxStaticText *RegIdxText;       ///< static text for reg idx
+  wxStaticText *WidthText;        ///< static text for width
+  wxStaticText *SubRegText;       ///< static text for sub registers
+
+  wxTextCtrl *RegNameCtrl;        ///< reg name ctrl
+  wxTextCtrl *RegIdxCtrl;         ///< reg idx ctrl
+  wxTextCtrl *WidthCtrl;          ///< reg width ctrl
+  wxTextCtrl *SubRegCtrl;         ///< sub register ctrl
+
+  wxCheckBox *SIMDCheck;          ///< simd reg check box
+  wxCheckBox *RWCheck;            ///< rw reg check box
+  wxCheckBox *ROCheck;            ///< ro reg check box
+  wxCheckBox *CSRCheck;           ///< csr reg check box
+  wxCheckBox *AMSCheck;           ///< ams reg check box
+  wxCheckBox *TUSCheck;           ///< tus reg check box
+  wxCheckBox *PCCheck;            ///< pc reg check box
+  wxCheckBox *SharedCheck;        ///< shared reg check box
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreRegInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreRegInfoWin.h
@@ -43,7 +43,7 @@ class CoreRegInfoWin : public wxDialog {
 public:
   CoreRegInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Inst Node"),
+                 const wxString& title = wxT("Reg Node"),
                  CoreGenReg *Node = nullptr);
   ~CoreRegInfoWin();
 

--- a/src/CoreGenPortal/PortalCore/CoreSocInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreSocInfoWin.cpp
@@ -29,7 +29,6 @@ CoreSocInfoWin::CoreSocInfoWin( wxWindow* parent,
   this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 
   // create the box sizers
-  wxBoxSizer *bSizer1 = new wxBoxSizer( wxVERTICAL );
   wxBoxSizer *bSizer2 = new wxBoxSizer( wxVERTICAL );
 
   m_panel1 = new wxPanel( this,
@@ -91,8 +90,7 @@ CoreSocInfoWin::CoreSocInfoWin( wxWindow* parent,
                                       wxDefaultPosition,
                                       wxDefaultSize,
                                       wxLI_HORIZONTAL );
-  bSizer2->Add( FinalStaticLine, 1, wxEXPAND|wxALL, 5 );
-  bSizer1->Add( bSizer2, 1, wxEXPAND, 5 );
+  bSizer2->Add( FinalStaticLine, 1, wxSHAPED|wxALL, 5 );
 
   // setup all the buttons
   wxBoxSizer *bSizer3 = new wxBoxSizer( wxVERTICAL );
@@ -102,13 +100,13 @@ CoreSocInfoWin::CoreSocInfoWin( wxWindow* parent,
   m_socbuttonsizer->AddButton( m_userOK );
   m_socbuttonsizer->Realize();
 
-  bSizer3->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
-  bSizer1->Add( bSizer3, 1, wxEXPAND, 5 );
+  bSizer3->Add( m_socbuttonsizer, 1, wxSHAPED, 5 );
+  bSizer2->Add( bSizer3, 1, wxSHAPED, 5 );
 
   // draw the dialog box until we get more info
-  this->SetSizer( bSizer1 );
+  this->SetSizer( bSizer2 );
   this->Layout();
-  bSizer1->Fit(this);
+  bSizer2->Fit(this);
   this->Centre(wxBOTH);
 }
 

--- a/src/CoreGenPortal/PortalCore/CoreSocInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreSocInfoWin.cpp
@@ -1,0 +1,122 @@
+//
+// _CORESOCINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreSocInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreSocInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreSocInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreSocInfoWin::CoreSocInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenSoC *Soc )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Soc == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the box sizers
+  wxBoxSizer *bSizer1 = new wxBoxSizer( wxVERTICAL );
+  wxBoxSizer *bSizer2 = new wxBoxSizer( wxVERTICAL );
+
+  m_panel1 = new wxPanel( this,
+                          wxID_ANY,
+                          wxDefaultPosition,
+                          wxDefaultSize,
+                          wxTAB_TRAVERSAL );
+  bSizer2->Add( m_panel1, 1, wxEXPAND|wxALL, 5);
+
+  // init all the options
+  //-- soc name
+  SocNameText = new wxStaticText(this,
+                                 wxID_ANY,
+                                 wxT("SoC Name"),
+                                 wxDefaultPosition,
+                                 wxDefaultSize,
+                                 0 );
+  SocNameText->Wrap(-1);
+  bSizer2->Add( SocNameText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- soc name box
+  SocNameCtrl = new wxTextCtrl(this,
+                               wxID_ANY,
+                               wxString(Soc->GetName()),
+                               wxDefaultPosition,
+                               wxSize(400,25),
+                               wxTE_READONLY,
+                               wxDefaultValidator,
+                               wxT("SoC Name") );
+  bSizer2->Add( SocNameCtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- core name
+  CoreNameText = new wxStaticText(this,
+                                 wxID_ANY,
+                                 wxT("Cores"),
+                                 wxDefaultPosition,
+                                 wxDefaultSize,
+                                 0 );
+  CoreNameText->Wrap(-1);
+  bSizer2->Add( CoreNameText, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  //-- cores
+  CoreNameCtrl = new wxTextCtrl(this,
+                               wxID_ANY,
+                               wxEmptyString,
+                               wxDefaultPosition,
+                               wxSize(400,100),
+                               wxTE_MULTILINE|wxTE_READONLY,
+                               wxDefaultValidator,
+                               wxT("Cores") );
+  for( unsigned i=0; i<Soc->GetNumCores(); i++ ){
+    CoreNameCtrl->AppendText( wxString(Soc->GetCore(i)->GetName()) + wxT("\n"));
+  }
+  bSizer2->Add( CoreNameCtrl, 0, wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( this,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  bSizer2->Add( FinalStaticLine, 1, wxEXPAND|wxALL, 5 );
+  bSizer1->Add( bSizer2, 1, wxEXPAND, 5 );
+
+  // setup all the buttons
+  wxBoxSizer *bSizer3 = new wxBoxSizer( wxVERTICAL );
+
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( this, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+
+  bSizer3->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+  bSizer1->Add( bSizer3, 1, wxEXPAND, 5 );
+
+  // draw the dialog box until we get more info
+  this->SetSizer( bSizer1 );
+  this->Layout();
+  bSizer1->Fit(this);
+  this->Centre(wxBOTH);
+}
+
+void CoreSocInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreSocInfoWin::~CoreSocInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreSocInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreSocInfoWin.h
@@ -1,0 +1,78 @@
+//
+// _CORESOCINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _CORESOCINFOWIN_H_
+#define _CORESOCINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreSocInfoWin : public wxDialog {
+public:
+  CoreSocInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("SoC Node"),
+                 CoreGenSoC *Node = nullptr);
+  ~CoreSocInfoWin();
+
+  wxStaticText *SocNameText;      ///< static text for SoC name
+  wxStaticText *CoreNameText;     ///< static text for core name
+  wxTextCtrl *SocNameCtrl;        ///< name of the SoC
+  wxTextCtrl *CoreNameCtrl;       ///< name of the Cores
+
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxPanel *m_panel1;              ///< main panel
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreSpadInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreSpadInfoWin.cpp
@@ -1,0 +1,184 @@
+//
+// _CORESPADINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreSpadInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreSpadInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreSpadInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreSpadInfoWin::CoreSpadInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenSpad *Spad )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( Spad == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- spad name
+  SpadNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Scratchpad Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  SpadNameText->Wrap(-1);
+  InnerSizer->Add( SpadNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  SpadNameCtrl = new wxTextCtrl( Wnd,
+                                 wxID_ANY,
+                                 wxString(Spad->GetName()),
+                                 wxDefaultPosition,
+                                 wxSize(400,25),
+                                 wxTE_READONLY,
+                                 wxDefaultValidator,
+                                 wxT("SpadName") );
+  InnerSizer->Add( SpadNameCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- scratchpad size
+  SizeNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Scratchpad Size (in bytes)"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  SizeNameText->Wrap(-1);
+  InnerSizer->Add( SizeNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  SizeCtrl = new wxTextCtrl( Wnd,
+                             wxID_ANY,
+                             wxString::Format(wxT("%i"),Spad->GetMemSize()),
+                             wxDefaultPosition,
+                             wxSize(400,25),
+                             wxTE_READONLY,
+                             wxDefaultValidator,
+                             wxT("SpadSize") );
+  InnerSizer->Add( SizeCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- request ports
+  RqstNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Request Ports"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  RqstNameText->Wrap(-1);
+  InnerSizer->Add( RqstNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  RqstCtrl = new wxTextCtrl( Wnd,
+                             wxID_ANY,
+                             wxString::Format(wxT("%i"),Spad->GetRqstPorts()),
+                             wxDefaultPosition,
+                             wxSize(400,25),
+                             wxTE_READONLY,
+                             wxDefaultValidator,
+                             wxT("RqstPorts") );
+  InnerSizer->Add( RqstCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- response ports
+  RspNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Response Ports"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  RspNameText->Wrap(-1);
+  InnerSizer->Add( RspNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  RspCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxString::Format(wxT("%i"),Spad->GetRspPorts()),
+                            wxDefaultPosition,
+                            wxSize(400,25),
+                            wxTE_READONLY,
+                            wxDefaultValidator,
+                            wxT("RspPorts") );
+  InnerSizer->Add( RspCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  //-- starting address
+  StartNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("Starting Memory Address"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  StartNameText->Wrap(-1);
+  InnerSizer->Add( StartNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // TODO: print this in hex
+  wxString tmp = wxString::Format("%" wxLongLongFmtSpec "u",
+                                  Spad->GetStartAddr() );
+  StartCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            tmp,
+                            wxDefaultPosition,
+                            wxSize(400,25),
+                            wxTE_READONLY,
+                            wxDefaultValidator,
+                            wxT("StartAddr") );
+  InnerSizer->Add( StartCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreSpadInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreSpadInfoWin::~CoreSpadInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreSpadInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreSpadInfoWin.h
@@ -1,0 +1,89 @@
+//
+// _CORESPADINFOWIN_H_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _CORESPADINFOWIN_H_
+#define _CORESPADINFOWIN_H_
+
+//-- WX HEADERS
+#include <wx/artprov.h>
+#include <wx/xrc/xmlres.h>
+#include <wx/string.h>
+#include <wx/listbox.h>
+#include <wx/gdicmn.h>
+#include <wx/font.h>
+#include <wx/colour.h>
+#include <wx/settings.h>
+#include <wx/sizer.h>
+#include <wx/dirctrl.h>
+#include <wx/aui/auibook.h>
+#include <wx/stattext.h>
+#include <wx/frame.h>
+#include <wx/panel.h>
+#include <wx/textctrl.h>
+#include <wx/choice.h>
+#include <wx/statline.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/msgdlg.h>
+#include <wx/textctrl.h>
+#include <wx/scrolwin.h>
+
+//-- COREGEN HEADERS
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+class CoreSpadInfoWin : public wxDialog {
+public:
+  CoreSpadInfoWin( wxWindow* parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& title = wxT("Scratchpad Node"),
+                 CoreGenSpad *Node = nullptr);
+  ~CoreSpadInfoWin();
+
+  // Event handler functions
+  /// Declares the event table
+  wxDECLARE_EVENT_TABLE();
+
+  /// handles the 'ok' button press
+  void OnPressOk( wxCommandEvent& event );
+
+protected:
+  // window handlers
+  wxScrolledWindow *Wnd;         ///< scrolling window handler
+
+  // box sizers
+  wxBoxSizer *OuterSizer;         ///< outer sizer
+  wxBoxSizer *InnerSizer;         ///< inner sizer
+
+  // static lines
+  wxStaticLine* FinalStaticLine;  ///< final static line
+
+  wxStaticText *SpadNameText;     ///< static text for spad name
+  wxStaticText *SizeNameText;     ///< static text for size name
+  wxStaticText *RqstNameText;     ///< static text for request ports
+  wxStaticText *RspNameText;      ///< static text for response ports
+  wxStaticText *StartNameText;    ///< static text for start address
+
+  wxTextCtrl *SpadNameCtrl;       ///< scratchpad name
+  wxTextCtrl *SizeCtrl;           ///< memsize
+  wxTextCtrl *RqstCtrl;           ///< rqst ports
+  wxTextCtrl *RspCtrl;            ///< rsp ports
+  wxTextCtrl *StartCtrl;          ///< starting address
+
+  // buttons
+  wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer
+  wxButton *m_userOK;                         ///< ok button
+
+private:
+};
+
+#endif
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreVTPInfoWin.cpp
+++ b/src/CoreGenPortal/PortalCore/CoreVTPInfoWin.cpp
@@ -1,0 +1,101 @@
+//
+// _COREVTPINFOWIN_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGenPortal/PortalCore/CoreVTPInfoWin.h"
+
+// Event Table
+wxBEGIN_EVENT_TABLE(CoreVTPInfoWin, wxDialog)
+  EVT_BUTTON(wxID_OK, CoreVTPInfoWin::OnPressOk)
+wxEND_EVENT_TABLE()
+
+CoreVTPInfoWin::CoreVTPInfoWin( wxWindow* parent,
+                              wxWindowID id,
+                              const wxString& title,
+                              CoreGenVTP *VTP )
+  : wxDialog( parent, id, title, wxDefaultPosition,
+              wxSize(500,500), wxDEFAULT_DIALOG_STYLE|wxVSCROLL ){
+  if( VTP == nullptr ){
+    this->EndModal(wxID_OK);
+  }
+
+  // init the internals
+  this->SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
+  this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+  // create the outer box sizer
+  OuterSizer = new wxBoxSizer( wxVERTICAL );
+
+  // create the scrolled window
+  Wnd = new wxScrolledWindow(this,
+                             wxID_ANY,
+                             wxDefaultPosition,
+                             wxDefaultSize,
+                             0,
+                             wxT("Scroll"));
+
+  // create the inner sizer
+  InnerSizer = new wxBoxSizer( wxVERTICAL );
+
+  // add all the interior data
+  //-- memory controller name
+  VTPNameText = new wxStaticText( Wnd,
+                                   wxID_ANY,
+                                   wxT("VTP Controller Name"),
+                                   wxDefaultPosition,
+                                   wxDefaultSize,
+                                   0 );
+  VTPNameText->Wrap(-1);
+  InnerSizer->Add( VTPNameText, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  VTPCtrl = new wxTextCtrl( Wnd,
+                            wxID_ANY,
+                            wxString(VTP->GetName()),
+                            wxDefaultPosition,
+                            wxSize(400,25),
+                            wxTE_READONLY,
+                            wxDefaultValidator,
+                            wxT("VTPName") );
+  InnerSizer->Add( VTPCtrl, 1, wxEXPAND|wxALIGN_CENTER|wxALL, 5 );
+
+  // add the static line
+  FinalStaticLine = new wxStaticLine( Wnd,
+                                      wxID_ANY,
+                                      wxDefaultPosition,
+                                      wxDefaultSize,
+                                      wxLI_HORIZONTAL );
+  InnerSizer->Add( FinalStaticLine, 1, wxEXPAND | wxALL, 5 );
+
+  // setup all the buttons
+  m_socbuttonsizer = new wxStdDialogButtonSizer();
+  m_userOK = new wxButton( Wnd, wxID_OK );
+  m_socbuttonsizer->AddButton( m_userOK );
+  m_socbuttonsizer->Realize();
+  InnerSizer->Add( m_socbuttonsizer, 1, wxEXPAND, 5 );
+
+  Wnd->SetScrollbars(20,20,50,50);
+  Wnd->SetSizer( InnerSizer );
+  Wnd->SetAutoLayout(true);
+  Wnd->Layout();
+
+  // draw the dialog box until we get more info
+  OuterSizer->Add(Wnd, 1, wxEXPAND | wxALL, 5 );
+  this->SetSizer( OuterSizer );
+  this->SetAutoLayout( true );
+  this->Layout();
+}
+
+void CoreVTPInfoWin::OnPressOk(wxCommandEvent& ok){
+  this->EndModal(wxID_OK);
+}
+
+CoreVTPInfoWin::~CoreVTPInfoWin(){
+}
+
+// EOF

--- a/src/CoreGenPortal/PortalCore/CoreVTPInfoWin.h
+++ b/src/CoreGenPortal/PortalCore/CoreVTPInfoWin.h
@@ -1,5 +1,5 @@
 //
-// _COREMCTRLINFOWIN_H_
+// _COREVTPINFOWIN_H_
 //
 // Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#ifndef _COREMCTRLINFOWIN_H_
-#define _COREMCTRLINFOWIN_H_
+#ifndef _COREVTPINFOWIN_H_
+#define _COREVTPINFOWIN_H_
 
 //-- WX HEADERS
 #include <wx/artprov.h>
@@ -39,13 +39,13 @@
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"
 
-class CoreMCtrlInfoWin : public wxDialog {
+class CoreVTPInfoWin : public wxDialog {
 public:
-  CoreMCtrlInfoWin( wxWindow* parent,
+  CoreVTPInfoWin( wxWindow* parent,
                  wxWindowID id = wxID_ANY,
-                 const wxString& title = wxT("Memory Controller Node"),
-                 CoreGenMCtrl *Node = nullptr);
-  ~CoreMCtrlInfoWin();
+                 const wxString& title = wxT("Virtual-to-Physical Node"),
+                 CoreGenVTP *Node = nullptr);
+  ~CoreVTPInfoWin();
 
   // Event handler functions
   /// Declares the event table
@@ -65,11 +65,9 @@ protected:
   // static lines
   wxStaticLine* FinalStaticLine;  ///< final static line
 
-  wxStaticText *MCtrlNameText;    ///< static text for memory controller name
-  wxStaticText *InputPortText;    ///< static text for input ports
+  wxStaticText *VTPNameText;      ///< static text for vtp name
 
-  wxTextCtrl *MCtrlCtrl;          ///< memory controller name
-  wxTextCtrl *InputPortCtrl;      ///< input ports for memory controller
+  wxTextCtrl *VTPCtrl;            ///< vtp name
 
   // buttons
   wxStdDialogButtonSizer* m_socbuttonsizer;   ///< button sizer

--- a/src/CoreGenPortal/PortalMain.cpp
+++ b/src/CoreGenPortal/PortalMain.cpp
@@ -54,7 +54,7 @@ bool CoreGenPortal::OnInit(){
   // Setup the main frame
   PortalMainFrame *MainFrame = new PortalMainFrame( "CoreGenPortal",
                                                     wxPoint(50,50),
-                                                    wxSize(1280,1024));
+                                                    wxSize(1024,768));
   MainFrame->Show( true );
   return true;
 }

--- a/src/CoreGenPortal/PortalMain.cpp
+++ b/src/CoreGenPortal/PortalMain.cpp
@@ -54,7 +54,7 @@ bool CoreGenPortal::OnInit(){
   // Setup the main frame
   PortalMainFrame *MainFrame = new PortalMainFrame( "CoreGenPortal",
                                                     wxPoint(50,50),
-                                                    wxSize(1024,768));
+                                                    wxSize(1280,1024));
   MainFrame->Show( true );
   return true;
 }

--- a/src/CoreGenPortal/PortalMainFrame.cpp
+++ b/src/CoreGenPortal/PortalMainFrame.cpp
@@ -404,6 +404,8 @@ void PortalMainFrame::LoadModuleBox(){
                                                 -1,
                                                 -1,
                                                 NULL ) );
+      LoadInstEncodings( NodeItems[NodeItems.size()-1],
+                         static_cast<CoreGenInst *>(Top->GetChild(i)));
       break;
     case CGPInst:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_PSEUDOINST],
@@ -411,6 +413,8 @@ void PortalMainFrame::LoadModuleBox(){
                                                 -1,
                                                 -1,
                                                 NULL ) );
+      LoadPInstEncodings( NodeItems[NodeItems.size()-1],
+                         static_cast<CoreGenPseudoInst *>(Top->GetChild(i)));
       break;
     case CGRegC:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REGCLASS],
@@ -420,7 +424,6 @@ void PortalMainFrame::LoadModuleBox(){
                                                 NULL ) );
       break;
     case CGReg:
-      LogPane->AppendText("Loading registers...\n" );
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REG],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
@@ -476,11 +479,49 @@ void PortalMainFrame::LoadModuleBox(){
                                                 wxTreeListCtrl::NO_IMAGE,
                                                 NULL ) );
       break;
+    case CGExt:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_EXT],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
     default:
-      LogPane->AppendText("Error loading module: " +
+      LogPane->AppendText("Error loading node: " +
                           wxString(Top->GetChild(i)->GetName()) + "\n");
       break;
     }
+  }
+
+  // expand the parent module
+  ModuleBox->Expand(ParentModule);
+}
+
+// PortalMainFrame::LoadInstEncodings
+// loads the wxTreeCtrl Inst node with its child encodings
+void PortalMainFrame::LoadInstEncodings( wxTreeItemId Parent,
+                                         CoreGenInst *Inst ){
+  for( unsigned j=0; j<Inst->GetNumEncodings(); j++ ){
+    CoreGenEncoding *E = Inst->GetEncoding(j);
+    EncItems.push_back( ModuleBox->AppendItem( Parent,
+                                               wxString(E->GetName()),
+                                               -1,
+                                               -1,
+                                               NULL ) );
+  }
+}
+
+// PortalMainFrame::LoadPInstEncodings
+// loads the wxTreeCtrl PInst node with its child encodings
+void PortalMainFrame::LoadPInstEncodings( wxTreeItemId Parent,
+                                         CoreGenPseudoInst *PInst ){
+  for( unsigned j=0; j<PInst->GetNumEncodings(); j++ ){
+    CoreGenEncoding *E = PInst->GetEncoding(j);
+    EncItems.push_back( ModuleBox->AppendItem( Parent,
+                                               wxString(E->GetName()),
+                                               -1,
+                                               -1,
+                                               NULL ) );
   }
 }
 

--- a/src/CoreGenPortal/PortalMainFrame.cpp
+++ b/src/CoreGenPortal/PortalMainFrame.cpp
@@ -237,7 +237,8 @@ void PortalMainFrame::CreateWindowLayout(){
 
   //-- setup the IR editor
   IRPane = new wxStyledTextCtrl(this, wxID_ANY);
-  IRPane->SetMarginWidth (MARGIN_LINE_NUMBERS, 10);
+  IRPane->StyleClearAll();
+  IRPane->SetMarginWidth(MARGIN_LINE_NUMBERS, 50);
   IRPane->SetTabWidth(3);
   IRPane->SetIndent(3);
   IRPane->SetUseTabs(false);
@@ -245,7 +246,6 @@ void PortalMainFrame::CreateWindowLayout(){
   IRPane->StyleSetBackground(wxSTC_STYLE_LINENUMBER, wxColour (220, 220, 220));
   IRPane->SetMarginType(MARGIN_LINE_NUMBERS, wxSTC_MARGIN_NUMBER);
   IRPane->SetWrapMode(wxSTC_WRAP_WORD);
-  IRPane->StyleClearAll();
   IRPane->SetLexer(wxSTC_LEX_YAML);
 
   // -- set all the colors

--- a/src/CoreGenPortal/PortalMainFrame.cpp
+++ b/src/CoreGenPortal/PortalMainFrame.cpp
@@ -366,6 +366,64 @@ void PortalMainFrame::SetupModuleBox(){
 
   // connect the module box window handlers
   Bind(wxEVT_TREE_ITEM_ACTIVATED, &PortalMainFrame::OnSelectNode, this);
+  Bind(wxEVT_TREE_ITEM_RIGHT_CLICK, &PortalMainFrame::OnRightClickNode, this);
+  Bind(wxEVT_TREE_ITEM_MIDDLE_CLICK, &PortalMainFrame::OnMiddleClickNode, this);
+}
+
+// PortalMainFrame::FindNodeStr
+// converts a node name into its appropriate Yaml text for searching
+wxString PortalMainFrame::FindNodeStr( CoreGenNode *Parent ){
+  switch( Parent->GetType() ){
+  case CGSoc:
+    return wxT("- Soc: ") + wxString(Parent->GetName());
+    break;
+  case CGCore:
+    return wxT("- Core: ") + wxString(Parent->GetName());
+    break;
+  case CGInstF:
+    return wxT("- InstFormatName: ") + wxString(Parent->GetName());
+    break;
+  case CGInst:
+    return wxT("- Inst: ") + wxString(Parent->GetName());
+    break;
+  case CGPInst:
+    return wxT("- PseudoInst: ") + wxString(Parent->GetName());
+    break;
+  case CGRegC:
+    return wxT("- RegisterClassname: ") + wxString(Parent->GetName());
+    break;
+  case CGReg:
+    return wxT("- RegName: ") + wxString(Parent->GetName());
+    break;
+  case CGISA:
+    return wxT("- ISAName: ") + wxString(Parent->GetName());
+    break;
+  case CGCache:
+    return wxT("- Cache: ") + wxString(Parent->GetName());
+    break;
+  case CGExt:
+    return wxT("- Extension: ") + wxString(Parent->GetName());
+    break;
+  case CGComm:
+    return wxT("- Comm: ") + wxString(Parent->GetName());
+    break;
+  case CGSpad:
+    return wxT("- Scratchpad: ") + wxString(Parent->GetName());
+    break;
+  case CGMCtrl:
+    return wxT("- MemoryController: ") + wxString(Parent->GetName());
+    break;
+  case CGVTP:
+    return wxT("- VTP: ") + wxString(Parent->GetName());
+    break;
+  case CGPlugin:
+    return wxT("- Plugin: ") + wxString(Parent->GetName());
+    break;
+  default:
+    return wxString(Parent->GetName());
+    break;
+  }
+  return wxString(Parent->GetName());
 }
 
 // PortalMainFrame::LoadModuleBox
@@ -383,113 +441,113 @@ void PortalMainFrame::LoadModuleBox(){
   for( unsigned i=0; i<Top->GetNumChild(); i++ ){
     switch( Top->GetChild(i)->GetType() ){
     case CGSoc:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_SOC],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_SOC],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGCore:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_CORE],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_CORE],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGInstF:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_INSTFORMAT],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_INSTFORMAT],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGInst:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_INST],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_INST],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
-      LoadInstEncodings( NodeItems[NodeItems.size()-1],
+                                                NULL ),Top->GetChild(i)) );
+      LoadInstEncodings( NodeItems[NodeItems.size()-1].first,
                          static_cast<CoreGenInst *>(Top->GetChild(i)));
       break;
     case CGPInst:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_PSEUDOINST],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_PSEUDOINST],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
-      LoadPInstEncodings( NodeItems[NodeItems.size()-1],
+                                                NULL ),Top->GetChild(i)) );
+      LoadPInstEncodings( NodeItems[NodeItems.size()-1].first,
                          static_cast<CoreGenPseudoInst *>(Top->GetChild(i)));
       break;
     case CGRegC:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REGCLASS],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_REGCLASS],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGReg:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REG],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_REG],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGISA:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_ISA],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_ISA],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGCache:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_CACHE],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_CACHE],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGComm:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_COMM],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_COMM],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGSpad:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_SPAD],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_SPAD],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGMCtrl:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_MCTRL],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_MCTRL],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGVTP:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_VTP],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_VTP],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 -1,
                                                 -1,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGPlugin:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_PLUGIN],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_PLUGIN],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 wxTreeListCtrl::NO_IMAGE,
                                                 wxTreeListCtrl::NO_IMAGE,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     case CGExt:
-      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_EXT],
+      NodeItems.push_back( std::make_pair(ModuleBox->AppendItem( TreeItems[TREE_NODE_EXT],
                                                 wxString(Top->GetChild(i)->GetName()),
                                                 wxTreeListCtrl::NO_IMAGE,
                                                 wxTreeListCtrl::NO_IMAGE,
-                                                NULL ) );
+                                                NULL ),Top->GetChild(i)) );
       break;
     default:
       LogPane->AppendText("Error loading node: " +
@@ -508,11 +566,11 @@ void PortalMainFrame::LoadInstEncodings( wxTreeItemId Parent,
                                          CoreGenInst *Inst ){
   for( unsigned j=0; j<Inst->GetNumEncodings(); j++ ){
     CoreGenEncoding *E = Inst->GetEncoding(j);
-    EncItems.push_back( ModuleBox->AppendItem( Parent,
+    EncItems.push_back( std::make_pair(ModuleBox->AppendItem( Parent,
                                                wxString(E->GetName()),
                                                -1,
                                                -1,
-                                               NULL ) );
+                                               NULL ),E) );
   }
 }
 
@@ -522,11 +580,11 @@ void PortalMainFrame::LoadPInstEncodings( wxTreeItemId Parent,
                                          CoreGenPseudoInst *PInst ){
   for( unsigned j=0; j<PInst->GetNumEncodings(); j++ ){
     CoreGenEncoding *E = PInst->GetEncoding(j);
-    EncItems.push_back( ModuleBox->AppendItem( Parent,
+    EncItems.push_back( std::make_pair(ModuleBox->AppendItem( Parent,
                                                wxString(E->GetName()),
                                                -1,
                                                -1,
-                                               NULL ) );
+                                               NULL ),E) );
   }
 }
 
@@ -596,6 +654,55 @@ void PortalMainFrame::OnAbout(wxCommandEvent &event){
   dial->ShowModal();
   delete dial;
   delete CGA;
+}
+
+// PortalMainFrame::OnRightClickNode
+void PortalMainFrame::OnRightClickNode(wxTreeEvent &event){
+}
+
+// PortalMainFrame::OnMiddleClickNode
+void PortalMainFrame::OnMiddleClickNode(wxTreeEvent &event){
+  // retrieve the name of the selection and search for it
+  // in the IRPane, then refocus the IRPane on the target node
+  wxTreeItemId SelId = ModuleBox->GetFocusedItem();
+
+  if( !SelId.IsOk() ){
+    LogPane->AppendText("Error: Could not select node\n");
+    return ;
+  }
+
+  bool done = false;
+
+  // we have a valid node, search for its corresponding object
+  for( unsigned i=0; i<NodeItems.size(); i++ ){
+    if( NodeItems[i].first == SelId ){
+      done = true;
+      int pos = IRPane->FindText(0,IRPane->GetLastPosition(),
+                                 FindNodeStr(NodeItems[i].second), 0 );
+      IRPane->GotoPos(pos);
+    }
+  }
+
+  if( !done ){
+    // we need to search the encoding blocks and retrieve the parent
+    for( unsigned i=0; i<EncItems.size(); i++ ){
+      if( EncItems[i].first == SelId ){
+        wxTreeItemId ParentId = ModuleBox->GetItemParent(EncItems[i].first);
+        for( unsigned j=0; j<NodeItems.size(); j++ ){
+          if( NodeItems[j].first == ParentId ){
+            done = true;
+            int pos = IRPane->FindText(0,IRPane->GetLastPosition(),
+                                 FindNodeStr(NodeItems[j].second), 0 );
+            IRPane->GotoPos(pos);
+          }
+        }
+      }
+    }
+  }
+
+  if( !done ){
+    LogPane->AppendText("Error: Could not retrieve appropriate node object\n" );
+  }
 }
 
 // PortalMainFrame::OnSelectNode

--- a/src/CoreGenPortal/PortalMainFrame.cpp
+++ b/src/CoreGenPortal/PortalMainFrame.cpp
@@ -212,8 +212,10 @@ void PortalMainFrame::CreateWindowLayout(){
                                       wxAUI_NB_TAB_MOVE |
                                       wxAUI_NB_SCROLL_BUTTONS);
 
-  ModuleBox = new wxTreeListCtrl(this, wxID_ANY, wxDefaultPosition,
-                                 wxDefaultSize, wxTL_MULTIPLE, wxEmptyString );
+  ModuleBox = new wxTreeCtrl(this, wxID_ANY, wxDefaultPosition,
+                             wxDefaultSize,
+                             wxTR_HAS_BUTTONS|wxTR_MULTIPLE,
+                             wxDefaultValidator, wxEmptyString );
   SetupModuleBox();
 
   PluginBox = new wxListBox(this, wxID_ANY, wxDefaultPosition,
@@ -281,92 +283,83 @@ void PortalMainFrame::CreateWindowLayout(){
 // PortalMainFrame::SetupModuleBox
 // initializes the modulebox tree hierarchy
 void PortalMainFrame::SetupModuleBox(){
-  ModuleBox->AppendColumn(wxT("Modules"),
-                          wxCOL_WIDTH_AUTOSIZE,
-                          wxALIGN_LEFT,
-                          wxCOL_RESIZABLE|wxCOL_SORTABLE);
-  ModuleBox->AppendColumn(wxT("Nodes"),
-                          wxCOL_WIDTH_AUTOSIZE,
-                          wxALIGN_LEFT,
-                          wxCOL_RESIZABLE|wxCOL_SORTABLE);
-  ModuleBox->AppendColumn(wxT("Encoding"),
-                          wxCOL_WIDTH_AUTOSIZE,
-                          wxALIGN_LEFT,
-                          wxCOL_RESIZABLE|wxCOL_SORTABLE);
+
+  ParentModule = ModuleBox->AddRoot(wxT("Nodes"), -1, -1, NULL);
+
   TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
                                               wxT("Cache"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("Comm"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("Core"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("Ext"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("ISA"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("Inst"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("InstFormat"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("MCtrl"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("Plugin"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("PseudoInst"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("Reg"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("RegClass"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("SoC"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("Spad"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
-  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+  TreeItems.push_back( ModuleBox->AppendItem( ParentModule,
                                               wxT("VTP"),
-                                              wxTreeListCtrl::NO_IMAGE,
-                                              wxTreeListCtrl::NO_IMAGE,
+                                              -1,
+                                              -1,
                                               NULL ) );
 }
 
@@ -387,92 +380,93 @@ void PortalMainFrame::LoadModuleBox(){
     case CGSoc:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_SOC],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGCore:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_CORE],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGInstF:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_INSTFORMAT],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGInst:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_INST],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGPInst:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_PSEUDOINST],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGRegC:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REGCLASS],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGReg:
+      LogPane->AppendText("Loading registers...\n" );
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REG],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGISA:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_ISA],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGCache:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_CACHE],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGComm:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_COMM],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGSpad:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_SPAD],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGMCtrl:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_MCTRL],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGVTP:
       NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_VTP],
                                                 wxString(Top->GetChild(i)->GetName()),
-                                                wxTreeListCtrl::NO_IMAGE,
-                                                wxTreeListCtrl::NO_IMAGE,
+                                                -1,
+                                                -1,
                                                 NULL ) );
       break;
     case CGPlugin:
@@ -501,6 +495,9 @@ void PortalMainFrame::CloseProject(){
 
   // save the IR file
   IRPane->SaveFile(IRFileName);
+
+  // clear the IR pane
+  IRPane->ClearAll();
 
   // close out all the modules
   // TODO
@@ -632,6 +629,12 @@ void PortalMainFrame::OnProjOpen(wxCommandEvent& WXUNUSED(event)){
     // read the ir
     if( !CGProject->ReadIR( std::string(NP.mb_str()) ) ){
       LogPane->AppendText( "Error reading IR into CoreGen from " + NP + wxT("\n") );
+      OpenDialog->Destroy();
+    }
+
+    // Force the DAG to build
+    if( !CGProject->BuildDAG() ){
+      LogPane->AppendText( "Error constructing DAG of hardware nodes\n" );
       OpenDialog->Destroy();
     }
 

--- a/src/CoreGenPortal/PortalMainFrame.cpp
+++ b/src/CoreGenPortal/PortalMainFrame.cpp
@@ -656,11 +656,6 @@ void PortalMainFrame::OnAbout(wxCommandEvent &event){
   delete CGA;
 }
 
-// PortalMainFrame::OpenNodeInfoWin
-void PortalMainFrame::OpenNodeInfoWin( CoreGenNode *Node ){
-  LogPane->AppendText("OpenNodeInfoWin\n");
-}
-
 // PortalMainFrame::OpenNodeEditWin
 void PortalMainFrame::OpenNodeEditWin( CoreGenNode *Node ){
   LogPane->AppendText("OpenNodeEditWin\n");
@@ -678,10 +673,13 @@ void PortalMainFrame::AddNodeWin(){
 
 // PortalMainFrame::OnPopupNode
 void PortalMainFrame::OnPopupNode(wxCommandEvent &event){
+  CoreInfoWin *InfoWin = nullptr;
   switch(event.GetId()){
   case ID_TREE_INFONODE:
-    // open a node info window
-    OpenNodeInfoWin(GetNodeFromItem(ModuleBox->GetFocusedItem()));
+    // open a node info window: TODO: change this to permit multiple selections
+    InfoWin = new CoreInfoWin(NULL,wxID_ANY,
+                              GetNodeFromItem(ModuleBox->GetFocusedItem()));
+    delete InfoWin;
     break;
   case ID_TREE_EDITNODE:
     // open an editor for the target node

--- a/src/CoreGenPortal/PortalMainFrame.cpp
+++ b/src/CoreGenPortal/PortalMainFrame.cpp
@@ -214,6 +214,8 @@ void PortalMainFrame::CreateWindowLayout(){
 
   ModuleBox = new wxTreeListCtrl(this, wxID_ANY, wxDefaultPosition,
                                  wxDefaultSize, wxTL_MULTIPLE, wxEmptyString );
+  SetupModuleBox();
+
   PluginBox = new wxListBox(this, wxID_ANY, wxDefaultPosition,
                             wxDefaultSize, 0, NULL, wxLB_MULTIPLE);
   ProjDir = new wxGenericDirCtrl(this,wxID_ANY, wxEmptyString,
@@ -274,6 +276,218 @@ void PortalMainFrame::CreateWindowLayout(){
   Mgr.AddPane( LogPane,         wxBOTTOM, wxT("CoreGenPortal Log"));
   Mgr.AddPane( EditorNotebook,  wxCENTER);
   Mgr.GetPane( EditorNotebook ).CloseButton(false);
+}
+
+// PortalMainFrame::SetupModuleBox
+// initializes the modulebox tree hierarchy
+void PortalMainFrame::SetupModuleBox(){
+  ModuleBox->AppendColumn(wxT("Modules"),
+                          wxCOL_WIDTH_AUTOSIZE,
+                          wxALIGN_LEFT,
+                          wxCOL_RESIZABLE|wxCOL_SORTABLE);
+  ModuleBox->AppendColumn(wxT("Nodes"),
+                          wxCOL_WIDTH_AUTOSIZE,
+                          wxALIGN_LEFT,
+                          wxCOL_RESIZABLE|wxCOL_SORTABLE);
+  ModuleBox->AppendColumn(wxT("Encoding"),
+                          wxCOL_WIDTH_AUTOSIZE,
+                          wxALIGN_LEFT,
+                          wxCOL_RESIZABLE|wxCOL_SORTABLE);
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Cache"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Comm"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Core"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Ext"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("ISA"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Inst"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("InstFormat"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("MCtrl"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Plugin"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("PseudoInst"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Reg"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("RegClass"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("SoC"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("Spad"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+  TreeItems.push_back( ModuleBox->AppendItem( ModuleBox->GetRootItem(),
+                                              wxT("VTP"),
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              wxTreeListCtrl::NO_IMAGE,
+                                              NULL ) );
+}
+
+// PortalMainFrame::LoadModuleBox
+// loads all the module box items
+void PortalMainFrame::LoadModuleBox(){
+  CoreGenNode *Top = CGProject->GetTop();
+
+  if( Top == nullptr ){
+    LogPane->AppendText("Error loading modules...\n");
+    return ;
+  }
+
+  LogPane->AppendText("Loading modules...\n" );
+
+  for( unsigned i=0; i<Top->GetNumChild(); i++ ){
+    switch( Top->GetChild(i)->GetType() ){
+    case CGSoc:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_SOC],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGCore:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_CORE],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGInstF:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_INSTFORMAT],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGInst:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_INST],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGPInst:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_PSEUDOINST],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGRegC:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REGCLASS],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGReg:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_REG],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGISA:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_ISA],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGCache:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_CACHE],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGComm:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_COMM],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGSpad:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_SPAD],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGMCtrl:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_MCTRL],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGVTP:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_VTP],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    case CGPlugin:
+      NodeItems.push_back( ModuleBox->AppendItem( TreeItems[TREE_NODE_PLUGIN],
+                                                wxString(Top->GetChild(i)->GetName()),
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                wxTreeListCtrl::NO_IMAGE,
+                                                NULL ) );
+      break;
+    default:
+      LogPane->AppendText("Error loading module: " +
+                          wxString(Top->GetChild(i)->GetName()) + "\n");
+      break;
+    }
+  }
 }
 
 // PortalMainFrame::CloseProject
@@ -424,6 +638,9 @@ void PortalMainFrame::OnProjOpen(wxCommandEvent& WXUNUSED(event)){
     // load the ir into the ir pane
     IRPane->LoadFile(NP);
     IRFileName = NP;
+
+    // load all the modules into the modulebox
+    LoadModuleBox();
 
     LogPane->AppendText( "Successfully opened project from IR at " + NP + wxT("\n" ));
   }

--- a/src/CoreGenPortal/PortalMainFrame.cpp
+++ b/src/CoreGenPortal/PortalMainFrame.cpp
@@ -157,6 +157,8 @@ void PortalMainFrame::CreateMenuBar(){
           wxCommandEventHandler(PortalMainFrame::OnProjNew));
   Connect(wxID_OPEN, wxEVT_COMMAND_MENU_SELECTED,
           wxCommandEventHandler(PortalMainFrame::OnProjOpen));
+  Connect(wxID_CLOSE, wxEVT_COMMAND_MENU_SELECTED,
+          wxCommandEventHandler(PortalMainFrame::OnProjClose));
 
   //-- build menu
 
@@ -361,6 +363,9 @@ void PortalMainFrame::SetupModuleBox(){
                                               -1,
                                               -1,
                                               NULL ) );
+
+  // connect the module box window handlers
+  Bind(wxEVT_TREE_ITEM_ACTIVATED, &PortalMainFrame::OnSelectNode, this);
 }
 
 // PortalMainFrame::LoadModuleBox
@@ -541,7 +546,12 @@ void PortalMainFrame::CloseProject(){
   IRPane->ClearAll();
 
   // close out all the modules
-  // TODO
+  NodeItems.clear();
+  EncItems.clear();
+  for( unsigned i=0; i<TreeItems.size(); i++ ){
+    ModuleBox->CollapseAndReset( TreeItems[i] );
+  }
+  ModuleBox->Collapse(ParentModule);
 
   // reset the file browser window
   ProjDir->SetPath(UserConfig->wxGetProjectDir());
@@ -588,7 +598,12 @@ void PortalMainFrame::OnAbout(wxCommandEvent &event){
   delete CGA;
 }
 
-// PortalMainFraml::OnVerifPref
+// PortalMainFrame::OnSelectNode
+void PortalMainFrame::OnSelectNode(wxTreeEvent &event){
+  LogPane->AppendText("selected a node");
+}
+
+// PortalMainFrame::OnVerifPref
 void PortalMainFrame::OnVerifPref(wxCommandEvent &event){
   LogPane->AppendText("Loading verification preferences...\n");
   PortalVerifPrefWin *VP = new PortalVerifPrefWin(this,
@@ -604,6 +619,7 @@ void PortalMainFrame::OnVerifPref(wxCommandEvent &event){
   VP->Destroy();
 }
 
+// PortalMainFrame::OnUserPref
 void PortalMainFrame::OnUserPref(wxCommandEvent &event){
   LogPane->AppendText("Loading user preferences...\n" );
   PortalUserPrefWin *UP = new PortalUserPrefWin(this,
@@ -619,6 +635,7 @@ void PortalMainFrame::OnUserPref(wxCommandEvent &event){
   UP->Destroy();
 }
 
+// PortalMainFrame::OnProjNew
 void PortalMainFrame::OnProjNew(wxCommandEvent &event){
   PortalNewProjWin *NP = new PortalNewProjWin(this,
                                               wxID_ANY,
@@ -638,6 +655,12 @@ void PortalMainFrame::OnProjNew(wxCommandEvent &event){
   }
 }
 
+// PortalMainFrame::OnProjClose
+void PortalMainFrame::OnProjClose(wxCommandEvent& WXUNUSED(event)){
+  CloseProject();
+}
+
+// PortalMainFrame::OnProjOpen
 void PortalMainFrame::OnProjOpen(wxCommandEvent& WXUNUSED(event)){
   // stage 1, decide whether we need to close the current project
   if( CGProject ){

--- a/src/CoreGenPortal/PortalMainFrame.h
+++ b/src/CoreGenPortal/PortalMainFrame.h
@@ -49,6 +49,7 @@
 #include "CoreGenPortal/PortalCore/CoreUserConfig.h"
 #include "CoreGenPortal/PortalCore/CoreVerifConfig.h"
 #include "CoreGenPortal/PortalCore/CoreConsts.h"
+#include "CoreGenPortal/PortalCore/CoreInfoWin.h"
 
 //-- COREGEN HEADERS
 #include "CoreGen/CoreGenBackend/CoreGenBackend.h"
@@ -118,7 +119,6 @@ private:
   void LoadInstEncodings(wxTreeItemId, CoreGenInst *Inst);
   void LoadPInstEncodings(wxTreeItemId, CoreGenPseudoInst *PInst);
   void CloseProject();
-  void OpenNodeInfoWin(CoreGenNode *N);
   void OpenNodeEditWin(CoreGenNode *N);
   void DeleteNode(CoreGenNode *N);
   void AddNodeWin();

--- a/src/CoreGenPortal/PortalMainFrame.h
+++ b/src/CoreGenPortal/PortalMainFrame.h
@@ -115,6 +115,8 @@ private:
   void CreateWindowLayout();
   void SetupModuleBox();
   void LoadModuleBox();
+  void LoadInstEncodings(wxTreeItemId, CoreGenInst *Inst);
+  void LoadPInstEncodings(wxTreeItemId, CoreGenPseudoInst *PInst);
 
   void CloseProject();
 

--- a/src/CoreGenPortal/PortalMainFrame.h
+++ b/src/CoreGenPortal/PortalMainFrame.h
@@ -101,12 +101,18 @@ private:
 
   wxString IRFileName;
 
+  std::vector<wxTreeListItem> TreeItems;
+  std::vector<wxTreeListItem> NodeItems;
+  std::vector<wxTreeListItem> EncItems;
+
   // private functions
   void InitAuiMgr();
   void UpdateAuiMgr();
   void CreateMenuBar();
   void CreatePortalToolBar();
   void CreateWindowLayout();
+  void SetupModuleBox();
+  void LoadModuleBox();
 
   void CloseProject();
 
@@ -135,6 +141,24 @@ enum
   ID_PREF_USER          = 40,
   ID_PREF_VERIF         = 41,
   ID_PREF_STONECUTTER   = 42
+};
+
+enum{
+  TREE_NODE_CACHE       = 0,
+  TREE_NODE_COMM        = 1,
+  TREE_NODE_CORE        = 2,
+  TREE_NODE_EXT         = 3,
+  TREE_NODE_ISA         = 4,
+  TREE_NODE_INST        = 5,
+  TREE_NODE_INSTFORMAT  = 6,
+  TREE_NODE_MCTRL       = 7,
+  TREE_NODE_PLUGIN      = 8,
+  TREE_NODE_PSEUDOINST  = 9,
+  TREE_NODE_REG         = 10,
+  TREE_NODE_REGCLASS    = 11,
+  TREE_NODE_SOC         = 12,
+  TREE_NODE_SPAD        = 13,
+  TREE_NODE_VTP         = 14
 };
 
 #endif

--- a/src/CoreGenPortal/PortalMainFrame.h
+++ b/src/CoreGenPortal/PortalMainFrame.h
@@ -127,6 +127,8 @@ private:
   void OnUserPref(wxCommandEvent& event);
   void OnProjNew(wxCommandEvent& event);
   void OnProjOpen(wxCommandEvent& event);
+  void OnProjClose(wxCommandEvent& event);
+  void OnSelectNode(wxTreeEvent& event);
 };
 
 enum
@@ -144,7 +146,8 @@ enum
   ID_COMPILE_COMPILER   = 31,
   ID_PREF_USER          = 40,
   ID_PREF_VERIF         = 41,
-  ID_PREF_STONECUTTER   = 42
+  ID_PREF_STONECUTTER   = 42,
+  ID_TREE_SELECTNODE    = 50
 };
 
 enum{

--- a/src/CoreGenPortal/PortalMainFrame.h
+++ b/src/CoreGenPortal/PortalMainFrame.h
@@ -118,8 +118,13 @@ private:
   void LoadInstEncodings(wxTreeItemId, CoreGenInst *Inst);
   void LoadPInstEncodings(wxTreeItemId, CoreGenPseudoInst *PInst);
   void CloseProject();
+  void OpenNodeInfoWin(CoreGenNode *N);
+  void OpenNodeEditWin(CoreGenNode *N);
+  void DeleteNode(CoreGenNode *N);
+  void AddNodeWin();
 
   wxString FindNodeStr(CoreGenNode *Parent);
+  CoreGenNode *GetNodeFromItem(wxTreeItemId Id);
 
   // menu handlers
   void OnQuit(wxCommandEvent& event);
@@ -132,6 +137,7 @@ private:
   void OnSelectNode(wxTreeEvent& event);
   void OnRightClickNode(wxTreeEvent& event);
   void OnMiddleClickNode(wxTreeEvent& event);
+  void OnPopupNode(wxCommandEvent &event);
 };
 
 enum
@@ -150,7 +156,11 @@ enum
   ID_PREF_USER          = 40,
   ID_PREF_VERIF         = 41,
   ID_PREF_STONECUTTER   = 42,
-  ID_TREE_SELECTNODE    = 50
+  ID_TREE_SELECTNODE    = 50,
+  ID_TREE_INFONODE      = 51,
+  ID_TREE_EDITNODE      = 52,
+  ID_TREE_ADDNODE       = 53,
+  ID_TREE_DELNODE       = 54
 };
 
 enum{

--- a/src/CoreGenPortal/PortalMainFrame.h
+++ b/src/CoreGenPortal/PortalMainFrame.h
@@ -104,8 +104,8 @@ private:
 
   wxTreeItemId ParentModule;
   std::vector<wxTreeItemId> TreeItems;
-  std::vector<wxTreeItemId> NodeItems;
-  std::vector<wxTreeItemId> EncItems;
+  std::vector<std::pair<wxTreeItemId,CoreGenNode *>> NodeItems;
+  std::vector<std::pair<wxTreeItemId,CoreGenEncoding *>> EncItems;
 
   // private functions
   void InitAuiMgr();
@@ -117,8 +117,9 @@ private:
   void LoadModuleBox();
   void LoadInstEncodings(wxTreeItemId, CoreGenInst *Inst);
   void LoadPInstEncodings(wxTreeItemId, CoreGenPseudoInst *PInst);
-
   void CloseProject();
+
+  wxString FindNodeStr(CoreGenNode *Parent);
 
   // menu handlers
   void OnQuit(wxCommandEvent& event);
@@ -129,6 +130,8 @@ private:
   void OnProjOpen(wxCommandEvent& event);
   void OnProjClose(wxCommandEvent& event);
   void OnSelectNode(wxTreeEvent& event);
+  void OnRightClickNode(wxTreeEvent& event);
+  void OnMiddleClickNode(wxTreeEvent& event);
 };
 
 enum

--- a/src/CoreGenPortal/PortalMainFrame.h
+++ b/src/CoreGenPortal/PortalMainFrame.h
@@ -37,6 +37,7 @@
 #include <wx/stc/stc.h>
 #include <wx/filedlg.h>
 #include <wx/treelist.h>
+#include <wx/treectrl.h>
 
 //-- PORTAL HEADERS
 #include "CoreGenPortal/PortalConsts.h"
@@ -92,7 +93,7 @@ private:
   // layout items
   wxTextCtrl *LogPane;
   wxAuiNotebook* ModulesNotebook;
-  wxTreeListCtrl *ModuleBox;
+  wxTreeCtrl *ModuleBox;
   wxListBox *PluginBox;
   wxGenericDirCtrl *ProjDir;
 
@@ -101,9 +102,10 @@ private:
 
   wxString IRFileName;
 
-  std::vector<wxTreeListItem> TreeItems;
-  std::vector<wxTreeListItem> NodeItems;
-  std::vector<wxTreeListItem> EncItems;
+  wxTreeItemId ParentModule;
+  std::vector<wxTreeItemId> TreeItems;
+  std::vector<wxTreeItemId> NodeItems;
+  std::vector<wxTreeItemId> EncItems;
 
   // private functions
   void InitAuiMgr();

--- a/src/CoreGenPortal/imgs/CMakeLists.txt
+++ b/src/CoreGenPortal/imgs/CMakeLists.txt
@@ -11,6 +11,6 @@
 file (COPY logo.png DESTINATION .)
 
 #-- install files
-install (FILES logo.png DESTINATION .)
+install (FILES logo.png DESTINATION bin/imgs/)
 
 #-- EOF


### PR DESCRIPTION
This pull request includes the following logic: 

- The node trees are nearly complete.  All child nodes except the children of extensions and plugins are expanded.  The latter should be trivial to complete
- Right and middle clicks on nodes is now functional.  Middle clicks trigger jumps to the respective IR block in the IR Pane.  Right clicks open a new window
- All node info can now be viewed from each node's right-click window

This merge **requires** logic from CoreGen from pull request #139