### PR TITLE
updating LLVM build harness for CMake to reflect native library linking

### DIFF
--- a/src/CoreGenPortal/CMakeLists.txt
+++ b/src/CoreGenPortal/CMakeLists.txt
@@ -27,21 +27,6 @@ PortalSCPrefWin.cpp
 PortalSCPrefWin.h
 )
 
-set(llvm_codegens
-  x86codegen
-  AArch64codegen
-  ARMcodegen
-  Mipscodegen
-  PowerPCcodegen
-)
-set(llvm_parsers
-  x86asmparser
-  AArch64asmparser
-  ARMasmparser
-  Mipsasmparser
-  PowerPCasmparser
-)
-
 llvm_map_components_to_libnames(llvm_libs
   support
   core
@@ -56,9 +41,7 @@ llvm_map_components_to_libnames(llvm_libs
   instcombine
   bitreader
   bitwriter
-  ${llvm_codegens}
-  ${llvm_parsers}
-)
+  native)
 
 #-- target deps
 find_package(wxWidgets COMPONENTS net adv aui core gl html propgrid qa ribbon richtext stc xrc base REQUIRED)


### PR DESCRIPTION
updating LLVM build harness for CMake to reflect native library linking; fix for Issue #144 